### PR TITLE
[Kernel] Opt-in attention + NVFP4-GEMM optimizations for nvidia/gemma-4-31B-it-NVFP4 on B200 (SM100)

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -164,6 +164,90 @@ if TYPE_CHECKING:
     VLLM_TPU_USING_PATHWAYS: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
+    # AMMO OP-004: route bf16 self-attention QKV/O projections through the
+    # FP8 (W8A8) cutlass_scaled_mm path. Defaults off for cross-track
+    # isolation; the E2E sweep enables it explicitly via opt_env.
+    VLLM_OP004_FP8_ATTN: bool = False
+    # AMMO OP-017: widen the prefill 2D global-attention BLOCK_M selection
+    # in unified-attention from 16 to 32, jointly with num_warps=8, for
+    # head_size==512 / num_queries_per_kv==8 (gemma-4 global). Defaults off
+    # for cross-track isolation; the E2E sweep enables it explicitly via
+    # opt_env. The (num_warps=8, BLOCK_M=16) cell measured 0.735x (a
+    # regression), so num_warps=8 MUST be conditioned on BLOCK_M==32 — the
+    # launcher in vllm/v1/attention/ops/triton_unified_attention.py enforces
+    # this jointly. Sliding-window layers (head_size==256) are NOT rerouted.
+    VLLM_OP017: bool = False
+    # AMMO OP-019: widen the prefill 2D sliding-window-attention BLOCK_M
+    # selection in unified-attention from 16 to 64, jointly with num_warps=8,
+    # for head_size==256 / num_queries_per_kv==2 / sliding_window>=0
+    # (gemma-4 sliding layers). Structural clone of OP-017 on a head_size-
+    # disjoint predicate (256 vs 512) — the two cannot both fire on the same
+    # launch. Defaults off for cross-track isolation; the E2E sweep enables
+    # it explicitly via opt_env. The (num_warps=8, BLOCK_M=16) cell measured
+    # 0.608x (a regression — same MMA-fragmentation pathology OP-017 §6.7
+    # documented), so num_warps=8 MUST be conditioned on BLOCK_M==64 — the
+    # launcher in vllm/v1/attention/ops/triton_unified_attention.py enforces
+    # this jointly. Global hd512 layers (head_size==512) are NOT rerouted by
+    # OP-019; that path is owned by OP-017.
+    VLLM_OP019: bool = False
+    # AMMO OP-033: TILE_SIZE 32->64 widening on the post-OP-019 sliding-
+    # window-attention 2D-prefill kernel_unified_attention. Stacks on top of
+    # OP-019's BLOCK_M=64 / num_warps=8 reroute on the SAME predicate
+    # (head_size==256 / num_queries_per_kv==2 / sliding_window>=0 /
+    # 2D-prefill), gated additionally by BLOCK_M==64 (i.e. only fires when
+    # VLLM_OP019 is also enabled).  TILE_SIZE is the K-loop tile width;
+    # doubling it from 32 to 64 halves the K-loop iteration count (and
+    # therefore halves the alpha-rescale recurrence hops on the binding
+    # latency path).  LOSSLESS: TILE_SIZE does not change tl.dot operand
+    # types or softmax precision.  Defaults off for cross-track isolation;
+    # the E2E sweep enables it explicitly via opt_env.  Eligibility framing
+    # (cubin-changing constexpr widening, NOT a config-only flip) mirrors
+    # OP-017/OP-019 — both shipped on this exact precedent.
+    VLLM_OP033: bool = False
+    # AMMO OP-039: authored per-shape NVFP4-linear dispatch predicate.  Routes
+    # the NVFP4 GEMM to flashinfer-cudnn at PREFILL-M (M >= threshold) and
+    # keeps the production flashinfer-cutlass at DECODE-M (M < threshold).
+    # Lossless (both backends are NVFP4 W4A4 with FP32 accumulation).  The
+    # decode regression at M=40 (cudnn 0.969x cutlass) — banked as
+    # exhausted_technology [30] for the bare global flip — is avoided here
+    # because the per-forward dispatch routes decode to cutlass.  Defaults
+    # off for cross-track isolation; the E2E sweep enables it explicitly via
+    # opt_env.  Eligibility framing (authored host-side selection code that
+    # alters which kernel runs) clears the Custom Kernel Mandate via path
+    # (ii); see rounds/22/debate/lead_independent_verification_op039.md and
+    # rounds/22/debate/investigator_op039_eligibility.md for primary-cited
+    # gate-pass reasoning.  The runtime-M branch is wrapped in an opaque
+    # custom op (vllm::op039_routed_fp4_mm) so Dynamo never traces the
+    # Python branch on x.shape[0] — Invariant 1 of
+    # references/torch-compile-contract.md.
+    VLLM_OP039: bool = False
+    # AMMO OP-039: M threshold above which cudnn is selected over cutlass for
+    # the NVFP4 GEMM.  Default 1024 was chosen from the crossover probe at
+    # rounds/22/tracks/OP-039/crossover_probe{,_extra}.json (B200; the
+    # gemma-4-31B-it-NVFP4 in-scope shapes for OP-039 — see below).
+    # IN-SCOPE shapes (the only NVFP4 linears under prod): gate_up_proj
+    # (N=43008,K=5376) and down_proj (N=5376,K=21504).  qkv_proj and o_proj
+    # are FP8 cutlass_scaled_mm under OP-004 (FP8-attn ON in production),
+    # NOT NVFP4 — they never reach this dispatch and are therefore out of
+    # scope.  At p50 (the noise-robust signal, NOT the noisy min) on the
+    # in-scope shapes at M>=1024:
+    #   - gate_up_proj: WIN at every M >= 1024 except M=6144 (p50 0.973x);
+    #   - down_proj:    WIN at every M tested >= 1024.
+    # The single mild in-scope p50 regression is gate_up_proj M=6144
+    # (-2.7% on that one MLP GEMM at one chunk-M).  Whether that cell
+    # carries material traffic on the chunked-prefill+MTP workload is an
+    # empirical question the OP039_COVERAGE_REPORT (M-histogram emitted at
+    # engine shutdown) answers; the MEASURED Gate-5.3b sweep is the
+    # magnitude arbiter (validation-defaults.md:374-380), and a global
+    # threshold=1024 E2E PASS is a conservative lower bound — a per-shape
+    # design that additionally excludes M=6144 could only improve it.
+    # Exposed as a knob so the validator can re-probe without rebuilding.
+    # Only consulted when VLLM_OP039 is on.  Re-gated default-OFF (0) so the
+    # PR "flags-off == base" invariant holds: with VLLM_OP039 off this knob is
+    # never read (init_nvfp4_linear_kernel does not select the routed kernel),
+    # and the E2E sweep sets the published threshold (1024) explicitly via
+    # opt_env.
+    VLLM_OP039_M_THRESHOLD: bool = False
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
     VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES: bool = True
     VLLM_DEEP_GEMM_WARMUP: Literal[
@@ -1261,6 +1345,35 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
     ),
+    # AMMO OP-004: enable FP8 (W8A8) cutlass_scaled_mm for the bf16
+    # self-attention QKV/O projections. Off by default (cross-track isolation).
+    "VLLM_OP004_FP8_ATTN": lambda: bool(
+        int(os.getenv("VLLM_OP004_FP8_ATTN", "0"))
+    ),
+    # AMMO OP-017: enable the BLOCK_M=32 / num_warps=8 reroute for the
+    # 2D-prefill global-attention launch (head_size==512, nqpkv==8) of
+    # kernel_unified_attention. Off by default (cross-track isolation).
+    "VLLM_OP017": lambda: bool(int(os.getenv("VLLM_OP017", "0"))),
+    # AMMO OP-019: enable the BLOCK_M=64 / num_warps=8 reroute for the
+    # 2D-prefill sliding-window-attention launch (head_size==256, nqpkv==2,
+    # sliding_window>=0) of kernel_unified_attention. Off by default
+    # (cross-track isolation).
+    "VLLM_OP019": lambda: bool(int(os.getenv("VLLM_OP019", "0"))),
+    # AMMO OP-033: enable the TILE_SIZE 32->64 widening on the post-OP-019
+    # sliding-window-attention 2D-prefill kernel_unified_attention launch
+    # (head_size==256, nqpkv==2, sliding_window>=0, 2D-prefill, BLOCK_M==64).
+    # Off by default (cross-track isolation).  Only fires when VLLM_OP019 is
+    # also enabled (BLOCK_M==64 binding).
+    "VLLM_OP033": lambda: bool(int(os.getenv("VLLM_OP033", "0"))),
+    # AMMO OP-039: route NVFP4 linear GEMMs to flashinfer-cudnn at
+    # prefill-M (M >= VLLM_OP039_M_THRESHOLD) while keeping flashinfer-cutlass
+    # at decode-M.  Off by default (cross-track isolation).
+    "VLLM_OP039": lambda: bool(int(os.getenv("VLLM_OP039", "0"))),
+    # AMMO OP-039: per-forward M threshold for the cudnn/cutlass dispatch
+    # predicate (only consulted when VLLM_OP039 is on).  Re-gated default-OFF
+    # ("0") so the PR "flags-off == base" invariant holds; the E2E sweep sets
+    # the published threshold (1024) explicitly via opt_env.
+    "VLLM_OP039_M_THRESHOLD": lambda: int(os.getenv("VLLM_OP039_M_THRESHOLD", "0")),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),
     # Allow use of DeepGemm specifically for MoE fused ops (overrides only MoE).

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -92,6 +92,9 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
     FlashInferCutlassNvFp4LinearKernel,
     FlashInferTrtllmNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.nvfp4.op039_shape_routed import (
+    OP039ShapeRoutedNvFp4LinearKernel,
+)
 from vllm.model_executor.kernels.linear.nvfp4.marlin import (
     MarlinNvFp4LinearKernel,
 )
@@ -623,6 +626,15 @@ def init_nvfp4_linear_kernel() -> NvFp4LinearKernel:
 
     # Env-var overrides.
     force_kernel: type[NvFp4LinearKernel] | None = None
+    # AMMO OP-039: when on, force the per-shape-routed wrapper that holds
+    # both cutlass and cudnn sub-kernels and dispatches at runtime on the
+    # token count M (cudnn at prefill-M, cutlass at decode-M).  This must
+    # take precedence over the ``VLLM_NVFP4_GEMM_BACKEND=...`` global flip
+    # so that asking for OP-039 unambiguously selects the routed path; it
+    # remains overridden by VLLM_BATCH_INVARIANT and VLLM_USE_FBGEMM /
+    # VLLM_USE_NVFP4_CT_EMULATIONS for the same reason the existing
+    # priority chain places those higher (deterministic / opt-in
+    # emulation modes outrank performance optimizations).
     if envs.VLLM_BATCH_INVARIANT:
         logger.info_once(
             "VLLM_BATCH_INVARIANT forces NVFP4 linear to use the "
@@ -633,6 +645,8 @@ def init_nvfp4_linear_kernel() -> NvFp4LinearKernel:
         force_kernel = FbgemmNvFp4LinearKernel
     elif envs.VLLM_USE_NVFP4_CT_EMULATIONS:
         force_kernel = EmulationNvFp4LinearKernel
+    elif envs.VLLM_OP039:
+        force_kernel = OP039ShapeRoutedNvFp4LinearKernel
     elif envs.VLLM_NVFP4_GEMM_BACKEND is not None:
         backend_name = envs.VLLM_NVFP4_GEMM_BACKEND
         force_kernel = _NVFP4_BACKEND_TO_KERNEL.get(backend_name)
@@ -787,6 +801,7 @@ __all__ = [
     "FlashInferCutlassNvFp4LinearKernel",
     "FlashInferTrtllmNvFp4LinearKernel",
     "FlashInferCudnnNvFp4LinearKernel",
+    "OP039ShapeRoutedNvFp4LinearKernel",
     "MarlinNvFp4LinearKernel",
     "_KernelT",
     "DeepGemmFp8BlockScaledMMKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/op039_shape_routed.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/op039_shape_routed.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""AMMO OP-039 — authored per-shape NVFP4 GEMM dispatch predicate.
+
+Routes the NVFP4 linear GEMM to ``flashinfer-cudnn`` at PREFILL-M (large M,
+where cudnn is measured 1.10–1.30× faster than the production cutlass on the
+real production GEMM shapes — see
+``rounds/22/tracks/OP-039/crossover_probe{,_extra}.json``) and keeps the
+production ``flashinfer-cutlass`` at DECODE-M (M ≈ 40, where cudnn regresses
+to 0.97×).  Lossless: both backends are NVFP4 W4A4 with FP32 accumulation.
+
+The decode regression that exhausted_technologies[14] banned for the BARE
+global env-flip (``VLLM_NVFP4_GEMM_BACKEND=flashinfer-cudnn``) is avoided
+here because the per-forward dispatch on the runtime token count routes
+decode → cutlass.  The authored host-side selection code that this wrapper
+introduces clears the Custom Kernel Mandate via path (ii) ("code that
+demonstrably alters which kernels run, when, or how their launches are
+coordinated"); see
+``rounds/22/debate/lead_independent_verification_op039.md`` and
+``rounds/22/debate/investigator_op039_eligibility.md`` for the primary-cited
+gate-pass reasoning.
+
+torch.compile / cudagraph contract (Invariant 1 of
+``references/torch-compile-contract.md``):
+
+The runtime-M branch lives **inside** an opaque ``torch.library.custom_op``
+(``vllm::op039_routed_fp4_mm``) so Dynamo never traces a Python ``if M >=
+threshold`` over a SymInt.  Two consequences:
+
+* The compiled FX graph contains exactly **one** call to
+  ``vllm::op039_routed_fp4_mm`` per linear forward — same shape and dtype
+  as the underlying ``vllm::flashinfer_mm_fp4``.  No graph break, no
+  per-range specialization, no compile-range explosion.
+* Backend selection happens at op-execution time on the live activation,
+  so a single captured cudagraph always replays with whichever backend
+  was chosen at *capture* time (decode capture sees small M → cutlass
+  baked; prefill, whether eager or piecewise-captured, sees its real M).
+  The replay is bit-stable because both cudnn and cutlass are CUDA-graph
+  capturable (champion-3 verified both backends capture cleanly at all
+  M tested).
+
+Invariant 3 (``mutates_args=[]``) is satisfied trivially — the wrapper is
+purely functional and returns the new tensor.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.utils.flashinfer import has_flashinfer
+
+from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
+from .flashinfer import (
+    FlashInferCudnnNvFp4LinearKernel,
+    FlashInferCutlassNvFp4LinearKernel,
+)
+
+logger = init_logger(__name__)
+
+__all__ = ["OP039ShapeRoutedNvFp4LinearKernel"]
+
+
+# ---------------------------------------------------------------------------
+# Opaque dispatch op
+# ---------------------------------------------------------------------------
+# The threshold is read once per process at op import time (it's a debug knob,
+# not a per-step parameter).  Reading it from ``envs`` inside the op body
+# would still be fine — Dynamo treats the entire op body as opaque — but
+# baking the constant here makes the dispatch a single integer comparison.
+
+_M_THRESHOLD = envs.VLLM_OP039_M_THRESHOLD if has_flashinfer() else None
+
+
+# ---------------------------------------------------------------------------
+# AMMO OP-039: dispatch-coverage instrumentation (mirrors OP-017 / OP-019 /
+# OP-033 pattern in vllm/v1/attention/ops/triton_unified_attention.py).
+# Counts the number of OP-039 routed NVFP4 GEMM calls per (shape, backend)
+# bucket and accumulates a per-shape M histogram, so we can compute the
+# realized in-scope coverage on the real chunked-prefill+MTP workload (the
+# crossover_probe + crossover_probe_extra grids only measure isolated GEMMs).
+# Both fastpath-evidence (proving the opt arm is not silently a baseline
+# run, per memory ``[ammo-opt-arm-silently-disabled-masquerades-as-clean]``)
+# and the deflation-by-coverage requirement from the lead's halt-revision
+# directive (rounds/22/tracks/OP-039/lead_disposition_halt_revision.md §A)
+# read this counter.  Only updated when VLLM_OP039 is ON to keep the
+# production hot path overhead-free.
+#
+# Shape key: (N, K) where N = output features per partition (= B.shape[1]
+# of the transposed weight passed into the routed op) and K = input
+# features (= 2 * B.shape[0] because the FP4 weight is packed [K/2, N]).
+# That keys the same way the crossover_probe.json does
+# (gate_up_proj N=43008 K=5376; down_proj N=5376 K=21504).
+# ---------------------------------------------------------------------------
+_op039_dispatch_counters: dict[str, int] = {
+    "calls_total": 0,
+    "calls_cudnn": 0,
+    "calls_cutlass": 0,
+    "env_off_total_calls": 0,
+}
+# (N, K, backend) -> {M -> count}.  We bucket M EXACTLY (no binning) so the
+# atexit dump can show the histogram at full resolution; the keyspace is
+# small in practice (a few dozen distinct M values per (shape, backend)
+# under chunked-prefill + MTP).
+_op039_m_histogram: dict[tuple[int, int, str], dict[int, int]] = {}
+_OP039_FIRST_FIRE_LOGGED = False
+
+
+def _op039_record_call(N: int, K: int, M: int, backend: str) -> None:
+    """Record one OP-039 dispatch.  Called only when VLLM_OP039 is ON."""
+    global _OP039_FIRST_FIRE_LOGGED
+    _op039_dispatch_counters["calls_total"] += 1
+    if backend == "cudnn":
+        _op039_dispatch_counters["calls_cudnn"] += 1
+    else:
+        _op039_dispatch_counters["calls_cutlass"] += 1
+    key = (N, K, backend)
+    bucket = _op039_m_histogram.get(key)
+    if bucket is None:
+        bucket = {}
+        _op039_m_histogram[key] = bucket
+    bucket[M] = bucket.get(M, 0) + 1
+    if not _OP039_FIRST_FIRE_LOGGED:
+        logger.info(
+            "OP039_ACTIVE backend=%s N=%d K=%d M=%d threshold=%s",
+            backend,
+            N,
+            K,
+            M,
+            _M_THRESHOLD,
+        )
+        _OP039_FIRST_FIRE_LOGGED = True
+
+
+def _op039_dump_counters_atexit() -> None:
+    """Dump the OP-039 dispatch-coverage counters on process exit.
+
+    Engine subprocesses (multiproc executor + spec-decode drafter) each own
+    their own copy of the module state; each subprocess runs its own atexit
+    hook.  Print to stderr so the line lands in the bench supervisor log
+    even if stdout is captured.
+
+    The report contains:
+      - per-backend call totals (`calls_cudnn`, `calls_cutlass`),
+      - per-(shape,backend) M histogram entries,
+      - aggregate ``env=OFF`` total when VLLM_OP039 is off (zero except for
+        the smoke-test path that flips the env mid-process).
+
+    The histogram lines are emitted as ``OP039_COVERAGE_HIST`` records so
+    the harness can grep them deterministically.  In-scope shapes for the
+    gemma-4-31B-it-NVFP4 production target (per
+    ``rounds/22/tracks/OP-039/crossover_probe{,_extra}.json``):
+      - gate_up_proj: N=43008, K=5376
+      - down_proj:    N=5376,  K=21504
+    OP-004 takes ``qkv_proj`` and ``o_proj`` to FP8/cutlass_scaled_mm out of
+    NVFP4 scope, so under prod they should NOT appear in this histogram.
+    """
+    pid = os.getpid()
+    if envs.VLLM_OP039:
+        c = _op039_dispatch_counters
+        msg = (
+            f"OP039_COVERAGE_REPORT pid={pid} env=ON "
+            f"threshold={_M_THRESHOLD} "
+            f"calls_total={c['calls_total']} "
+            f"calls_cudnn={c['calls_cudnn']} "
+            f"calls_cutlass={c['calls_cutlass']}"
+        )
+    else:
+        msg = (
+            f"OP039_COVERAGE_REPORT pid={pid} env=OFF "
+            f"env_off_total_calls={_op039_dispatch_counters['env_off_total_calls']}"
+        )
+    import sys as _sys
+    print(msg, flush=True, file=_sys.stderr)
+    # Per-(shape,backend) histogram lines — keep them on separate lines so
+    # the harness can grep / parse without choking on a giant single line.
+    if envs.VLLM_OP039:
+        for (N, K, backend), m_counts in sorted(_op039_m_histogram.items()):
+            # Compact "M:cnt,M:cnt,..." encoding sorted by M.
+            hist_str = ",".join(
+                f"{m}:{cnt}" for m, cnt in sorted(m_counts.items())
+            )
+            total = sum(m_counts.values())
+            print(
+                f"OP039_COVERAGE_HIST pid={pid} N={N} K={K} backend={backend} "
+                f"calls={total} hist={hist_str}",
+                flush=True,
+                file=_sys.stderr,
+            )
+
+
+# Register the atexit hook exactly once per process.
+if not getattr(atexit, "_op039_registered", False):
+    atexit.register(_op039_dump_counters_atexit)
+    atexit._op039_registered = True  # type: ignore[attr-defined]
+
+
+if has_flashinfer():
+
+    @torch.library.custom_op(
+        "vllm::op039_routed_fp4_mm",
+        mutates_args=[],
+        device_types="cuda",
+    )
+    def op039_routed_fp4_mm(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+        g_scale: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """OP-039 dispatch: cudnn at prefill-M, cutlass at decode-M.
+
+        ``A`` is shape ``[M, K/2]`` (packed FP4); the dispatch routes on the
+        ``A.shape[0]`` runtime value, which is always concrete at execution
+        time (the SymInt has been resolved by then).
+        """
+        from flashinfer import mm_fp4 as flashinfer_mm_fp4_
+
+        # The threshold is a process-level constant captured at import.
+        M = A.shape[0]
+        if M >= _M_THRESHOLD:
+            backend = "cudnn"
+        else:
+            backend = "cutlass"
+
+        # Coverage instrumentation — gated on VLLM_OP039 to keep the
+        # env-off hot path overhead-free.  When VLLM_OP039 is OFF this
+        # custom op is not even reachable (init_nvfp4_linear_kernel will
+        # not select OP039ShapeRoutedNvFp4LinearKernel), but we still
+        # increment ``env_off_total_calls`` defensively for the smoke-test
+        # path that flips the env mid-process via importlib.reload.
+        if envs.VLLM_OP039:
+            # B was passed as ``layer.weight.t()``.  After
+            # ``pad_nvfp4_weight_for_cutlass`` the original weight shape is
+            # ``[N, K/2]`` (N rows, K-bytes packed columns — see
+            # ``vllm/model_executor/layers/quantization/utils/nvfp4_utils.py``
+            # ``pad_nvfp4_weight_for_cutlass``).  After the transpose
+            # ``B.shape == [K/2, N]``, so we recover K from
+            # ``B.shape[0] * 2`` and N from ``B.shape[1]``.  This matches
+            # the crossover_probe convention (gate_up_proj N=43008 K=5376;
+            # down_proj N=5376 K=21504).
+            K = int(B.shape[0]) * 2
+            N = int(B.shape[1])
+            _op039_record_call(N, K, int(M), backend)
+        else:
+            _op039_dispatch_counters["env_off_total_calls"] += 1
+
+        return flashinfer_mm_fp4_(
+            A,
+            B,
+            A_scale,
+            B_scale,
+            g_scale,
+            dtype,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend=backend,
+        )
+
+    @torch.library.register_fake("vllm::op039_routed_fp4_mm")
+    def op039_routed_fp4_mm_fake(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+        g_scale: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        return torch.empty(A.shape[0], B.shape[1], dtype=dtype, device=A.device)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper kernel
+# ---------------------------------------------------------------------------
+class OP039ShapeRoutedNvFp4LinearKernel(NvFp4LinearKernel):
+    """OP-039: per-forward M-routed NVFP4 linear kernel wrapper.
+
+    Holds a single processed weight set (cutlass and cudnn share the
+    swizzled+padded NVFP4 layout — ``FlashInferCutlassNvFp4LinearKernel`` and
+    ``FlashInferCudnnNvFp4LinearKernel`` both call
+    ``swizzle_blockscale`` + ``pad_nvfp4_weight_for_cutlass``).  Dispatches
+    per-forward via the opaque ``vllm::op039_routed_fp4_mm`` custom op above,
+    keeping the runtime-M branch invisible to Dynamo (Invariant 1 of the
+    torch-compile contract).
+
+    This subclass exists exclusively as a vehicle for the authored
+    dispatch predicate — its ``apply_weights`` signature, weight prep, and
+    output reshape all match the production ``FlashInferCutlassNvFp4LinearKernel``
+    1-to-1, the only difference is the GEMM call.
+    """
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        # Both sub-kernels must be available.  Reuse their checks rather than
+        # duplicating the ``cutlass_fp4_supported() and >=sm_100 and
+        # has_flashinfer()`` invariant.
+        ok_cutlass, why_cutlass = FlashInferCutlassNvFp4LinearKernel.is_supported(
+            compute_capability
+        )
+        if not ok_cutlass:
+            return False, f"OP-039 unsupported (cutlass sub-kernel): {why_cutlass}"
+        ok_cudnn, why_cudnn = FlashInferCudnnNvFp4LinearKernel.is_supported(
+            compute_capability
+        )
+        if not ok_cudnn:
+            return False, f"OP-039 unsupported (cudnn sub-kernel): {why_cudnn}"
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # cutlass and cudnn share the same on-device weight layout, so a
+        # single in-place transform covers both backends.  We delegate to
+        # the cutlass subclass's transform — they're literally identical
+        # (compare ``FlashInferCutlassNvFp4LinearKernel`` and
+        # ``FlashInferCudnnNvFp4LinearKernel`` ``process_weights_after_loading``).
+        FlashInferCutlassNvFp4LinearKernel.process_weights_after_loading(self, layer)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        from vllm._custom_ops import scaled_fp4_quant
+        from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+            pad_nvfp4_activation_for_cutlass,
+            slice_nvfp4_output,
+        )
+
+        output_size = layer.output_size_per_partition
+        output_dtype = x.dtype
+        output_shape = [*x.shape[:-1], output_size]
+
+        # NVFP4 quant prep is identical for cutlass and cudnn (both consume
+        # the swizzled-SF layout); we use the cutlass tag because cuDNN's
+        # backend-specific quant path is functionally equivalent (compare
+        # FlashInferCutlassNvFp4LinearKernel.apply_weights and
+        # FlashInferCudnnNvFp4LinearKernel.apply_weights — only the backend=
+        # string differs in the GEMM call).
+        x_fp4, x_blockscale = scaled_fp4_quant(
+            x,
+            layer.input_global_scale_inv,
+            is_sf_swizzled_layout=True,
+            backend="flashinfer-cutlass",
+        )
+
+        x_fp4 = pad_nvfp4_activation_for_cutlass(
+            x_fp4, getattr(layer, "weights_padding_cols", 0)
+        )
+
+        # Match the same operand-prep that the production
+        # ``flashinfer_scaled_fp4_mm`` performs before delegating to
+        # ``flashinfer_mm_fp4`` (uint8 view + transpose of weight and
+        # weight-scale).  We do the transpose+view here so that the routed
+        # custom op below has the same K-aligned operand contract as
+        # ``vllm::flashinfer_mm_fp4``.
+        b = layer.weight
+        block_scale_a = x_blockscale.view(torch.uint8)
+        block_scale_b = layer.weight_scale.view(torch.uint8)
+
+        # Single opaque op call — Dynamo traces this as one node, never
+        # sees the M-branch inside.  This is the load-bearing line that
+        # makes OP-039 graph-safe under torch.compile / cudagraph capture.
+        out = torch.ops.vllm.op039_routed_fp4_mm(
+            x_fp4,
+            b.t(),
+            block_scale_a,
+            block_scale_b.t(),
+            layer.alpha,
+            output_dtype,
+        )
+
+        out = slice_nvfp4_output(out, output_size)
+
+        if bias is not None:
+            out = out + bias
+        return out.view(*output_shape)

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -191,6 +191,19 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         # handle exclusion
         if self.is_layer_excluded(prefix):
             if isinstance(layer, LinearBase):
+                # AMMO OP-004: the modelopt NVFP4 checkpoint excludes all
+                # self-attention QKV/O projections from FP4, so they run bf16.
+                # When VLLM_OP004_FP8_ATTN is set, route just those projections
+                # through the FP8 (W8A8) cutlass_scaled_mm path instead. lm_head
+                # and vision-tower layers stay bf16 (out of scope).
+                from vllm.model_executor.layers.quantization.op004_fp8_attn import (
+                    Op004Fp8AttnLinearMethod,
+                    is_op004_attn_projection,
+                    op004_fp8_attn_enabled,
+                )
+
+                if op004_fp8_attn_enabled() and is_op004_attn_projection(prefix):
+                    return Op004Fp8AttnLinearMethod(prefix=prefix)
                 return UnquantizedLinearMethod()
             return None
 

--- a/vllm/model_executor/layers/quantization/op004_fp8_attn.py
+++ b/vllm/model_executor/layers/quantization/op004_fp8_attn.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMMO OP-004: FP8 (W8A8) replacement for the bf16 self-attention QKV/O
+projection GEMMs.
+
+Context
+-------
+The ``nvidia/gemma-4-31B-it-NVFP4`` checkpoint quantizes only the MLP Linears
+to NVFP4. All 60 layers' ``self_attn*`` projections (and ``lm_head`` / vision
+tower) are in the modelopt ``quantization_config.ignore`` list, so they fall
+through to :class:`UnquantizedLinearMethod` and run bf16 on cuBLASLt nvJet.
+
+At decode (M = 5-160 tokens) these GEMMs are **weight-load HBM-bandwidth
+bound** (NCU: bf16 at 65.7% of HBM peak, 179.6 MB/QKV-layer). bf16 cannot move
+fewer weight bytes, so the only physical lever is precision reduction. FP8-e4m3
+weights halve the weight stream (NCU: 179.6 -> 90.6 MB, 1.98x) and route through
+vLLM's SM100-native ``cutlass_scaled_mm`` (``SM100_MMA_F8F6F4``).
+
+This is a **LOSSY** optimization (bf16 -> fp8-e4m3, per-channel weight scale +
+per-token dynamic activation scale). It is gated behind ``VLLM_OP004_FP8_ATTN``
+(default on); set ``VLLM_OP004_FP8_ATTN=0`` to fall back to the original bf16
+path for clean A/B ablation.
+
+Design (production-parity, torch.compile-safe)
+----------------------------------------------
+* ``create_weights`` is inherited from :class:`UnquantizedLinearMethod`, so the
+  bf16 weight loads exactly as in the baseline (no checkpoint-format change).
+* ``process_weights_after_loading`` quantizes the loaded bf16 ``[N, K]`` weight
+  to fp8-e4m3 **once** with a per-output-channel scale, then stores it
+  column-major ``[K, N]`` as ``cutlass_scaled_mm`` requires (``b.stride(0)==1``).
+* ``apply`` per-token-dynamic-quantizes the bf16 activation via the registered
+  ``QuantFP8`` CustomOp (so the existing ``RMSNormQuantFusionPass`` can fuse the
+  preceding ``input_layernorm`` RMSNorm into the QKV act-quant at TP=1), then
+  calls the registered ``cutlass_scaled_mm`` op. Both are graph-visible
+  registered ops -- no opaque wrapper, no Python shape branch, no in-place
+  mutation -- satisfying torch-compile-contract invariants 1/3/4/5.
+"""
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm import envs
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.layer_utils import (
+    replace_parameter,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+
+def op004_fp8_attn_enabled() -> bool:
+    """Master enable flag for the OP-004 FP8 attention-projection path."""
+    return bool(getattr(envs, "VLLM_OP004_FP8_ATTN", False))
+
+
+def is_op004_attn_projection(prefix: str) -> bool:
+    """True iff ``prefix`` names a self-attention QKV or O projection.
+
+    Scope is deliberately narrow: ONLY language-model ``*.self_attn.qkv_proj``
+    and ``*.self_attn.o_proj``. This must NOT match ``lm_head`` (also excluded
+    from FP4) or vision-tower attention, which are out of OP-004's scope (the
+    bottleneck is the 60 language-model decoder layers).
+    """
+    if "vision_tower" in prefix or "vision_model" in prefix:
+        return False
+    if ".self_attn." not in prefix:
+        return False
+    return prefix.endswith("qkv_proj") or prefix.endswith("o_proj")
+
+
+class Op004Fp8AttnLinearMethod(UnquantizedLinearMethod):
+    """W8A8 FP8 linear method for the bf16 self-attention QKV/O projections.
+
+    Inherits ``create_weights`` (bf16 weight allocation + standard weight
+    loader) from :class:`UnquantizedLinearMethod`; overrides
+    ``process_weights_after_loading`` (one-time weight quant) and ``apply``
+    (per-token act-quant + ``cutlass_scaled_mm``).
+    """
+
+    def __init__(self, prefix: str = "") -> None:
+        super().__init__()
+        self.prefix = prefix
+        self.fp8_dtype = current_platform.fp8_dtype()
+        # Per-token dynamic activation quantization. Using the registered
+        # QuantFP8 CustomOp (rather than a raw ops.scaled_fp8_quant call) keeps
+        # the lowered graph node identical to production fp8 paths, so the
+        # RMSNorm->dynamic-per-token-fp8-quant fusion pattern can match.
+        self.act_quant = QuantFP8(static=False, group_shape=GroupShape.PER_TOKEN)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight = layer.weight
+        # Idempotency guard: only quantize a still-bf16 weight once.
+        if weight.dtype == self.fp8_dtype:
+            return
+        if weight.dim() != 2:
+            # Not a standard 2D Linear weight; leave untouched (defensive).
+            logger.warning(
+                "OP-004: skipping FP8 quant for %s (weight ndim=%d)",
+                self.prefix,
+                weight.dim(),
+            )
+            return
+
+        # weight is [N, K] (output_channels, input). Quantize per-output-channel
+        # (treat each output row as a "token" -> one fp8 scale per output
+        # channel). scaled_fp8_quant(use_per_token_if_dynamic=True) returns
+        # (fp8 weight [N, K], scale [N, 1] float32).
+        w_bf16 = weight.data.contiguous()
+        qweight, weight_scale = ops.scaled_fp8_quant(
+            w_bf16, scale=None, use_per_token_if_dynamic=True
+        )
+
+        # cutlass_scaled_mm requires b column-major ([K, N], stride(0)==1).
+        # qweight is [N, K] row-major -> .t() is [K, N] with stride (1, K).
+        qweight_t = qweight.t()
+
+        replace_parameter(layer, "weight", qweight_t)
+        layer.register_parameter(
+            "weight_scale",
+            torch.nn.Parameter(weight_scale.contiguous(), requires_grad=False),
+        )
+
+        # cutlass_scaled_mm requires b column-major (b.stride(0) == 1). The
+        # transpose above yields that layout; assert it survived
+        # replace_parameter so any future regression fails loudly at load time
+        # rather than as a cryptic CUDA stride-check crash in the first forward.
+        assert layer.weight.stride(0) == 1, (
+            f"OP-004 {self.prefix}: fp8 weight is not column-major "
+            f"(stride={layer.weight.stride()}); cutlass_scaled_mm requires "
+            f"b.stride(0)==1. Do NOT call .contiguous() on the transposed weight."
+        )
+
+        # Fast-path activation proof (the E2E sweep matches this as a
+        # require_pattern to prove the FP8 path actually fired in the opt run).
+        logger.info(
+            "OP004_FP8_ACTIVE cutlass_scaled_mm fp8 attn-proj quantized: %s "
+            "[K=%d,N=%d]",
+            self.prefix,
+            layer.weight.shape[0],
+            layer.weight.shape[1],
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # x: [..., K] bf16. Flatten to 2D for the GEMM.
+        x_2d = x.view(-1, x.shape[-1])
+
+        # Per-token dynamic fp8 activation quant: x_fp8 [M, K], x_scale [M, 1].
+        x_fp8, x_scale = self.act_quant(x_2d)
+
+        # layer.weight is fp8 [K, N] column-major; weight_scale is [N, 1] f32.
+        weight = layer.weight
+        weight_scale = layer.weight_scale
+        n = weight.shape[1]
+
+        out = ops.cutlass_scaled_mm(
+            x_fp8,
+            weight,
+            scale_a=x_scale,
+            scale_b=weight_scale,
+            out_dtype=x.dtype,
+            bias=bias,
+        )
+        return out.view(*x.shape[:-1], n)

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -73,6 +73,11 @@ class TritonAttentionMetadata:
     softmax_segm_output: torch.Tensor
     softmax_segm_max: torch.Tensor
     softmax_segm_expsum: torch.Tensor
+    # Per-(spec-)decode-step query length (1 for pure decode, 1 + num_spec for
+    # MTP/EAGLE).  Gates the 3D flash-decoding path for spec-decode in the
+    # ``unified_attention`` launcher.  Set by the builder from the speculative
+    # config (1 when spec-decode is inactive).
+    decode_query_len: int
 
     # For cascade attention.
     use_cascade: bool
@@ -174,11 +179,32 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 key=lambda x: abs(x - self.seq_threshold_3D),
             )
 
+        # Per-(spec-)decode-step query length: 1 for pure decode, or
+        # ``1 + num_speculative_tokens`` when MTP/EAGLE speculative decode is
+        # active (e.g. 5 for num_speculative_tokens=4).  Under spec-decode a
+        # uniform decode step packs up to ``decode_query_len`` query tokens per
+        # sequence, so the 3D segment buffers — which are indexed by the
+        # absolute within-batch query-token position (``query_offset_0`` in
+        # ``kernel_unified_attention``), not by sequence index — must size their
+        # first dim by ``seq_threshold_3D * decode_query_len`` to admit a full
+        # spec-verify batch (num_seqs <= seq_threshold_3D, each with up to
+        # decode_query_len tokens).  With ``decode_query_len == 1`` (non-spec)
+        # this reduces to the original ``seq_threshold_3D`` first dim — no
+        # behavior or memory change for non-spec deployments.
+        spec_config = self.vllm_config.speculative_config
+        self.decode_query_len = 1 + (
+            spec_config.num_speculative_tokens
+            if spec_config is not None
+            and spec_config.num_speculative_tokens is not None
+            else 0
+        )
+        segm_first_dim = self.seq_threshold_3D * self.decode_query_len
+
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                segm_first_dim,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 headdim_padded,
@@ -187,14 +213,35 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_first_dim, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_first_dim, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
+        )
+        # Buffer-safety invariant (applies to BOTH the global and sliding
+        # builder instances since this __init__ is shared).  The 3D epilogue in
+        # ``kernel_unified_attention`` indexes all three segment buffers by the
+        # absolute within-batch query-token position, whose max over a
+        # 3D-admitted batch is (num_actual_tokens - 1) <= seq_threshold_3D *
+        # decode_query_len - 1.  All three buffers must therefore share the
+        # first dim ``seq_threshold_3D * decode_query_len``; assert the actual
+        # allocated shapes to fail fast on a half-applied resize.
+        expected_first_dim = self.seq_threshold_3D * self.decode_query_len
+        assert (
+            self.softmax_segm_output.shape[0] == expected_first_dim
+            and self.softmax_segm_max.shape[0] == expected_first_dim
+            and self.softmax_segm_expsum.shape[0] == expected_first_dim
+        ), (
+            "3D softmax segment buffers must all have first dim "
+            f"seq_threshold_3D({self.seq_threshold_3D}) * "
+            f"decode_query_len({self.decode_query_len}) = {expected_first_dim}; "
+            f"got output={self.softmax_segm_output.shape[0]}, "
+            f"max={self.softmax_segm_max.shape[0]}, "
+            f"expsum={self.softmax_segm_expsum.shape[0]}."
         )
 
     def build_for_cudagraph_capture(
@@ -258,6 +305,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             softmax_segm_output=self.softmax_segm_output,
             softmax_segm_max=self.softmax_segm_max,
             softmax_segm_expsum=self.softmax_segm_expsum,
+            decode_query_len=self.decode_query_len,
         )
         return attn_metadata
 
@@ -626,6 +674,7 @@ class TritonAttentionImpl(AttentionImpl):
             k_descale=k_descale,
             v_descale=v_descale,
             seq_threshold_3D=seq_threshold_3D,
+            decode_query_len=attn_metadata.decode_query_len,
             num_par_softmax_segments=num_par_softmax_segments,
             softmax_segm_output=softmax_segm_output,
             softmax_segm_max=softmax_segm_max,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -139,37 +139,34 @@ def init_softmax_M(
 
 
 @triton.jit
-def compute_tile_loop_bounds(
+def compute_window_tile_range(
     context_len,
     seq_len,
     cur_batch_query_len,
     q_block_local_idx,
-    segm_idx_or_0,
-    tiles_per_segment_or_0,
     TILE_SIZE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_Q: tl.constexpr,
     num_queries_per_kv: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
     USE_MM_PREFIX: tl.constexpr,
-    IS_3D: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
-    derived ``max_seq_prefix_len`` used for per-tile masking.
+    """Single source of truth for the *un-segmented* tile range
+    ``[tile_start, tile_end)`` spanned by one q-block, plus the
+    derived ``max_seq_prefix_len``.
 
-    Combines three concerns into one helper:
+    Factored out of ``compute_tile_loop_bounds`` so that the attention
+    mainloop, ``compute_tile_loop_bounds``, AND ``reduce_segments`` can
+    all derive the IDENTICAL window range from the same q-block
+    geometry.  This is the keystone that prevents the mainloop and the
+    3D reduction from disagreeing on the window-relative segment layout
+    (OP-003): any drift between the two would silently read stale /
+    mis-masked segment partials.
 
-    1. Longest prefix spanned by any query token in this q-block.
-       Clamped to ``seq_len`` (causal) or extended to it when
-       mm_prefix is active (bidirectional ranges can reach past the
-       causal prefix).
-    2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
-       only tiles that can contain an allowed key under SWA.
-    3. 3D scoping: when ``IS_3D`` is True, further narrows to the
-       segment's slice via ``(segm_idx * tiles_per_segment,
-       (segm_idx + 1) * tiles_per_segment)``.
+    For ``SLIDING_WINDOW <= 0`` (global layers) this returns
+    ``[0, num_tiles)`` — byte-identical to the previous inline logic.
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -217,9 +214,134 @@ def compute_tile_loop_bounds(
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
+    return tile_start, tile_end, max_seq_prefix_len
+
+
+@triton.jit
+def compute_window_segments(
+    context_len,
+    seq_len,
+    cur_batch_query_len,
+    q_block_local_idx,
+    NUM_SEGMENTS: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    USE_MM_PREFIX: tl.constexpr,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+):
+    """Window-relative 3D segmentation for one q-block (OP-003).
+
+    Returns ``(tile_start, tiles_per_segment, act_num_segments)`` where
+    the ``NUM_SEGMENTS`` parallel-softmax segments tile ONLY the
+    sliding window's tile range ``[tile_start, tile_end)`` rather than
+    the full sequence.  At 27k context with a 1024 window this restores
+    ~11/16 active segments vs the window-blind 1/16 collapse.
+
+    The mainloop (for its early-return + loop bounds) and
+    ``reduce_segments`` (for its segment mask) MUST call this with the
+    SAME q-block geometry so their ``act_num_segments`` agree — the
+    mainloop early-returns (does not overwrite) empty high segments, so
+    the reduction relies on the matching mask to exclude stale data.
+    """
+    tile_start, tile_end, _ = compute_window_tile_range(
+        context_len,
+        seq_len,
+        cur_batch_query_len,
+        q_block_local_idx,
+        TILE_SIZE,
+        BLOCK_M,
+        BLOCK_Q,
+        num_queries_per_kv,
+        SLIDING_WINDOW,
+        USE_MM_PREFIX,
+        CHUNK_LOOKBACK,
+        CHUNK_SIZE,
+    )
+    window_tiles = tile_end - tile_start
+    # window_tiles >= 1 whenever the q-block has any allowed key (the
+    # caller only reaches here for non-empty q-blocks); guard anyway so
+    # cdiv never divides by zero.
+    window_tiles = tl.maximum(window_tiles, 1)
+    tiles_per_segment = cdiv_fn(window_tiles, NUM_SEGMENTS)
+    act_num_segments = cdiv_fn(window_tiles, tiles_per_segment)
+    return tile_start, tiles_per_segment, act_num_segments
+
+
+@triton.jit
+def compute_tile_loop_bounds(
+    context_len,
+    seq_len,
+    cur_batch_query_len,
+    q_block_local_idx,
+    segm_idx_or_0,
+    tiles_per_segment_or_0,
+    TILE_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    USE_MM_PREFIX: tl.constexpr,
+    IS_3D: tl.constexpr,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+    WINDOW_SEG_3D: tl.constexpr = False,
+):
+    """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
+    derived ``max_seq_prefix_len`` used for per-tile masking.
+
+    Combines three concerns into one helper:
+
+    1. Longest prefix spanned by any query token in this q-block.
+       Clamped to ``seq_len`` (causal) or extended to it when
+       mm_prefix is active (bidirectional ranges can reach past the
+       causal prefix).
+    2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
+       only tiles that can contain an allowed key under SWA.
+    3. 3D scoping: when ``IS_3D`` is True, further narrows to the
+       segment's slice.  Two segmentation modes:
+       - ``WINDOW_SEG_3D`` (OP-003): segments tile the WINDOW range
+         ``[tile_start, tile_end)`` — base offset by ``tile_start``.
+       - default: full-sequence segmentation via
+         ``(segm_idx * tiles_per_segment, (segm_idx + 1) *
+         tiles_per_segment)`` (GLOBAL + existing behavior, unchanged).
+    """
+    tile_start, tile_end, max_seq_prefix_len = compute_window_tile_range(
+        context_len,
+        seq_len,
+        cur_batch_query_len,
+        q_block_local_idx,
+        TILE_SIZE,
+        BLOCK_M,
+        BLOCK_Q,
+        num_queries_per_kv,
+        SLIDING_WINDOW,
+        USE_MM_PREFIX,
+        CHUNK_LOOKBACK,
+        CHUNK_SIZE,
+    )
+
     if IS_3D:
-        loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
-        loop_hi = min((segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end)
+        if WINDOW_SEG_3D:
+            # Window-relative segmentation: the ``NUM_SEGMENTS`` segments
+            # tile only the window range ``[tile_start, tile_end)``, with
+            # segment ``segm_idx`` covering
+            # ``[tile_start + segm_idx*tps, tile_start + (segm_idx+1)*tps)``.
+            # ``tiles_per_segment_or_0`` is the WINDOW-relative tps the
+            # mainloop computed via ``compute_window_segments`` on the
+            # same q-block geometry; ``tile_start`` is re-derived here from
+            # the shared ``compute_window_tile_range`` — so neither value
+            # can drift from the early-return / reduce_segments view.
+            loop_lo = max(tile_start + segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
+            loop_hi = min(
+                tile_start + (segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end
+            )
+        else:
+            loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
+            loop_hi = min((segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end)
     else:
         loop_lo = tile_start
         loop_hi = tile_end

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -7,6 +7,8 @@
 #  - Chih-Chieh Yang <chih.chieh.yang@ibm.com>
 #  - Thomas Parnell <tpa@zurich.ibm.com>
 
+import atexit
+import os
 from typing import Any
 
 import torch
@@ -21,6 +23,7 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
     cdiv_fn,
     compute_kv_seq_mask,
     compute_tile_loop_bounds,
+    compute_window_segments,
     find_seq_idx,
     init_softmax_M,
     load_qq_bias_tile,
@@ -33,6 +36,248 @@ from vllm.v1.kv_cache_interface import KVQuantMode
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+
+# AMMO OP-017: dispatch-coverage instrumentation.  Counts the number of
+# unified_attention launches by category so we can compute the realized
+# coverage fraction of the BLOCK_M=32 / num_warps=8 reroute on the real
+# workload (chunked-prefill input-len 27000 + MTP spec-decode).  Both
+# fastpath-evidence (proving the opt arm is not silently a baseline run)
+# and the deflation-by-coverage requirement from the lead's HARD pre-
+# validator gate read this counter.  Only updated when VLLM_OP017_COVERAGE
+# is enabled to keep the production hot path overhead-free.
+_op017_dispatch_counters: dict[str, int] = {
+    "rerouted_global_2d_prefill": 0,
+    "passthru_global_3d_decode": 0,
+    "passthru_sliding_2d": 0,
+    "passthru_sliding_3d": 0,
+    "passthru_other_head_size": 0,
+    "passthru_other_nqpkv": 0,
+    "env_off_total_launches": 0,
+}
+_OP017_FIRST_FIRE_LOGGED = False
+_OP017_FIRST_PASSTHRU_LOGGED = False
+
+# AMMO OP-019: dispatch-coverage instrumentation (mirrors OP-017's pattern).
+# Counts the number of unified_attention launches by category so we can
+# compute the realized coverage fraction of the BLOCK_M=64 / num_warps=8
+# reroute on the real workload (chunked-prefill input-len 27000 + MTP
+# spec-decode).  Both fastpath-evidence (proving the opt arm is not silently
+# a baseline run) and the deflation-by-coverage requirement from the lead's
+# obligation C read this counter.  Coverage =
+# rerouted_sliding_2d_prefill / (rerouted_sliding_2d_prefill +
+# passthru_sliding_3d_decode + passthru_sliding_other_nqpkv).  The
+# denominator excludes global-attention shapes (head_size==512, owned by
+# OP-017) and includes only launches where the sliding-attention head_size /
+# nqpkv could in principle be rerouted by OP-019.  Per memory
+# `[ammo-opt-arm-silently-disabled-masquerades-as-clean]` this is the guard
+# against a silently-disabled opt arm.
+_op019_dispatch_counters: dict[str, int] = {
+    "rerouted_sliding_2d_prefill": 0,
+    "passthru_sliding_3d_decode": 0,
+    "passthru_sliding_global": 0,        # head_size==256 but window_size<0
+    "passthru_sliding_other_nqpkv": 0,    # head_size==256 + sliding but nqpkv != 2
+    "passthru_global_head_size": 0,       # head_size==512 (OP-017 territory)
+    "passthru_other_head_size": 0,        # head_size not in {256, 512}
+    "env_off_total_launches": 0,
+}
+_OP019_FIRST_FIRE_LOGGED = False
+_OP019_FIRST_PASSTHRU_LOGGED = False
+
+
+# AMMO OP-033: dispatch-coverage instrumentation (mirrors OP-017 / OP-019).
+# OP-033 is a strict reslice of OP-019's coverage set: the TILE=64 widening
+# fires IFF the OP-019 BLOCK_M=64 reroute has fired AND VLLM_OP033 is on.
+# Same fastpath-evidence + deflation-by-coverage rationale per memory
+# `[ammo-opt-arm-silently-disabled-masquerades-as-clean]`.  Coverage =
+# rerouted_tile64_2d_prefill / (rerouted_tile64_2d_prefill +
+# passthru_op019_off_2d_prefill + passthru_sliding_3d_decode +
+# passthru_sliding_other_nqpkv).
+_op033_dispatch_counters: dict[str, int] = {
+    "rerouted_tile64_2d_prefill": 0,
+    "passthru_op019_off_2d_prefill": 0,    # head_size==256+nqpkv==2+sliding+2D
+                                            # but VLLM_OP019 is OFF -> BLOCK_M=16
+    "passthru_sliding_3d_decode": 0,
+    "passthru_sliding_global": 0,           # head_size==256, sliding_window<0
+    "passthru_sliding_other_nqpkv": 0,
+    "passthru_global_head_size": 0,
+    "passthru_other_head_size": 0,
+    "env_off_total_launches": 0,
+}
+_OP033_FIRST_FIRE_LOGGED = False
+
+
+def _op017_dump_counters_atexit() -> None:
+    """Dump the dispatch-coverage counters on process exit.
+
+    Engine subprocesses (multiproc executor + spec-decode drafter) each
+    own their own copy of the module state; each subprocess runs its own
+    atexit hook.  We print to stderr so the line lands in the bench
+    supervisor log even if stdout is captured.
+
+    Coverage = rerouted_global_2d_prefill / (rerouted_global_2d_prefill +
+    passthru_global_3d_decode + passthru_other_nqpkv + passthru_other_head_size).
+    The denominator excludes sliding-window shapes (separately scoped to
+    §6.4) and includes only launches where the global-attention head_size /
+    nqpkv could in principle be rerouted.
+    """
+    pid = os.getpid()
+    if envs.VLLM_OP017:
+        c = _op017_dispatch_counters
+        total_global_eligible_shapes = (
+            c["rerouted_global_2d_prefill"]
+            + c["passthru_global_3d_decode"]
+            + c["passthru_other_nqpkv"]
+        )
+        # head_size==512 launches that did or could have rerouted (excluding
+        # sliding hd256 — those have their own §6.4 obligation).
+        if total_global_eligible_shapes > 0:
+            cov_pct = (
+                100.0
+                * c["rerouted_global_2d_prefill"]
+                / total_global_eligible_shapes
+            )
+        else:
+            cov_pct = 0.0
+        # Stamp the message with a unique tag so the harness can grep it
+        # out of the supervisor log and the engine subprocess logs.
+        msg = (
+            f"OP017_COVERAGE_REPORT pid={pid} env=ON "
+            f"rerouted={c['rerouted_global_2d_prefill']} "
+            f"passthru_global_3d_decode={c['passthru_global_3d_decode']} "
+            f"passthru_sliding_2d={c['passthru_sliding_2d']} "
+            f"passthru_sliding_3d={c['passthru_sliding_3d']} "
+            f"passthru_other_head_size={c['passthru_other_head_size']} "
+            f"passthru_other_nqpkv={c['passthru_other_nqpkv']} "
+            f"global_eligible_total={total_global_eligible_shapes} "
+            f"coverage_global_2d_prefill_pct={cov_pct:.2f}"
+        )
+    else:
+        msg = (
+            f"OP017_COVERAGE_REPORT pid={pid} env=OFF "
+            f"env_off_total_launches="
+            f"{_op017_dispatch_counters['env_off_total_launches']}"
+        )
+    # Print to stderr so it lands even if stdout is buffered/captured.
+    import sys as _sys
+    print(msg, flush=True, file=_sys.stderr)
+
+
+# Register the atexit hook exactly once per process.  The smoke test
+# uses importlib.reload() to flip envs.VLLM_OP017 mid-run; without this
+# guard each reload would push another copy of the hook onto the atexit
+# stack and the report would print N times at process exit.
+if not getattr(atexit, "_op017_registered", False):
+    atexit.register(_op017_dump_counters_atexit)
+    atexit._op017_registered = True  # type: ignore[attr-defined]
+
+
+def _op019_dump_counters_atexit() -> None:
+    """Dump the OP-019 dispatch-coverage counters on process exit (mirrors
+    OP-017).
+
+    Coverage = rerouted_sliding_2d_prefill / (rerouted_sliding_2d_prefill +
+    passthru_sliding_3d_decode + passthru_sliding_other_nqpkv).  The
+    denominator covers launches where the sliding-window head_size==256 path
+    was eligible in principle; head_size==512 / global / other heads are
+    excluded (different OP-id territories).
+    """
+    pid = os.getpid()
+    if envs.VLLM_OP019:
+        c = _op019_dispatch_counters
+        total_sliding_eligible_shapes = (
+            c["rerouted_sliding_2d_prefill"]
+            + c["passthru_sliding_3d_decode"]
+            + c["passthru_sliding_other_nqpkv"]
+        )
+        if total_sliding_eligible_shapes > 0:
+            cov_pct = (
+                100.0
+                * c["rerouted_sliding_2d_prefill"]
+                / total_sliding_eligible_shapes
+            )
+        else:
+            cov_pct = 0.0
+        msg = (
+            f"OP019_COVERAGE_REPORT pid={pid} env=ON "
+            f"rerouted={c['rerouted_sliding_2d_prefill']} "
+            f"passthru_sliding_3d_decode={c['passthru_sliding_3d_decode']} "
+            f"passthru_sliding_global={c['passthru_sliding_global']} "
+            f"passthru_sliding_other_nqpkv={c['passthru_sliding_other_nqpkv']} "
+            f"passthru_global_head_size={c['passthru_global_head_size']} "
+            f"passthru_other_head_size={c['passthru_other_head_size']} "
+            f"sliding_eligible_total={total_sliding_eligible_shapes} "
+            f"coverage_sliding_2d_prefill_pct={cov_pct:.2f}"
+        )
+    else:
+        msg = (
+            f"OP019_COVERAGE_REPORT pid={pid} env=OFF "
+            f"env_off_total_launches="
+            f"{_op019_dispatch_counters['env_off_total_launches']}"
+        )
+    import sys as _sys
+    print(msg, flush=True, file=_sys.stderr)
+
+
+if not getattr(atexit, "_op019_registered", False):
+    atexit.register(_op019_dump_counters_atexit)
+    atexit._op019_registered = True  # type: ignore[attr-defined]
+
+
+def _op033_dump_counters_atexit() -> None:
+    """Dump the OP-033 dispatch-coverage counters on process exit (mirrors
+    OP-017 / OP-019).
+
+    Coverage = rerouted_tile64_2d_prefill / (rerouted_tile64_2d_prefill +
+    passthru_op019_off_2d_prefill + passthru_sliding_3d_decode +
+    passthru_sliding_other_nqpkv).  The denominator covers launches where
+    the sliding-window head_size==256 path was eligible in principle for
+    the TILE=64 stacked widening (i.e. would have rerouted under OP-019
+    BLOCK_M=64).  Other head sizes / shapes are tagged for diagnostics.
+    """
+    pid = os.getpid()
+    if envs.VLLM_OP033:
+        c = _op033_dispatch_counters
+        total_eligible = (
+            c["rerouted_tile64_2d_prefill"]
+            + c["passthru_op019_off_2d_prefill"]
+            + c["passthru_sliding_3d_decode"]
+            + c["passthru_sliding_other_nqpkv"]
+        )
+        if total_eligible > 0:
+            cov_pct = (
+                100.0
+                * c["rerouted_tile64_2d_prefill"]
+                / total_eligible
+            )
+        else:
+            cov_pct = 0.0
+        msg = (
+            f"OP033_COVERAGE_REPORT pid={pid} env=ON "
+            f"rerouted={c['rerouted_tile64_2d_prefill']} "
+            f"passthru_op019_off_2d_prefill="
+            f"{c['passthru_op019_off_2d_prefill']} "
+            f"passthru_sliding_3d_decode={c['passthru_sliding_3d_decode']} "
+            f"passthru_sliding_global={c['passthru_sliding_global']} "
+            f"passthru_sliding_other_nqpkv="
+            f"{c['passthru_sliding_other_nqpkv']} "
+            f"passthru_global_head_size={c['passthru_global_head_size']} "
+            f"passthru_other_head_size={c['passthru_other_head_size']} "
+            f"sliding_eligible_total={total_eligible} "
+            f"coverage_tile64_2d_prefill_pct={cov_pct:.2f}"
+        )
+    else:
+        msg = (
+            f"OP033_COVERAGE_REPORT pid={pid} env=OFF "
+            f"env_off_total_launches="
+            f"{_op033_dispatch_counters['env_off_total_launches']}"
+        )
+    import sys as _sys
+    print(msg, flush=True, file=_sys.stderr)
+
+
+if not getattr(atexit, "_op033_registered", False):
+    atexit.register(_op033_dump_counters_atexit)
+    atexit._op033_registered = True  # type: ignore[attr-defined]
 
 
 @triton.jit
@@ -140,6 +385,13 @@ def kernel_unified_attention(
     # over ``SLIDING_WINDOW`` inside the helpers.  ``-1`` disables.
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    # OP-003: when True (3D + sliding-window + spec-decode regime), the
+    # ``NUM_SEGMENTS_PER_SEQ`` parallel-softmax segments tile only the
+    # sliding window's tile range rather than the full sequence, so
+    # segment parallelism is not collapsed to 1/NSEG at long context.
+    # Default False preserves the full-sequence (global / existing)
+    # segmentation byte-for-byte.
+    WINDOW_SEG_3D: tl.constexpr = False,
 ):
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
 
@@ -160,10 +412,41 @@ def kernel_unified_attention(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    # context_len is needed both for window segmentation (3D) and the
+    # tile loop below; compute it once here.
+    context_len = seq_len - cur_batch_query_len
+
     if IS_3D:
-        tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
-        if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
-            return
+        if WINDOW_SEG_3D:
+            # Window-relative segmentation (OP-003): segments tile only
+            # the sliding window's tile range for THIS q-block.  The
+            # early-return below skips segments past the window's active
+            # count; those segment buffers are left untouched and are
+            # masked out by ``reduce_segments`` (which recomputes the
+            # SAME act_num_segments via compute_window_segments).
+            _ws_tile_start, tiles_per_segment, _ws_act_segments = (
+                compute_window_segments(
+                    context_len,
+                    seq_len,
+                    cur_batch_query_len,
+                    q_block_local_idx,
+                    NUM_SEGMENTS_PER_SEQ,
+                    TILE_SIZE,
+                    BLOCK_M,
+                    BLOCK_Q,
+                    num_queries_per_kv,
+                    SLIDING_WINDOW,
+                    USE_MM_PREFIX,
+                    CHUNK_LOOKBACK,
+                    CHUNK_SIZE,
+                )
+            )
+            if segm_idx >= _ws_act_segments:
+                return
+        else:
+            tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+            if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
+                return
     else:
         tiles_per_segment = 0
 
@@ -200,8 +483,6 @@ def kernel_unified_attention(
     # acc : (BLOCK_M, HEAD_SIZE_PADDED)
     acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED], dtype=tl.float32)
 
-    context_len = seq_len - cur_batch_query_len
-
     if USE_ALIBI_SLOPES:
         alibi_slope = tl.load(
             alibi_slopes_ptr + query_offset_1, mask=query_mask_1, other=0.0
@@ -226,6 +507,7 @@ def kernel_unified_attention(
         IS_3D,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        WINDOW_SEG_3D,
     )
 
     # iterate through tiles (now limited to the sliding window range)
@@ -407,6 +689,19 @@ def reduce_segments(
     USE_FP8: tl.constexpr,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    # OP-003 window-relative segmentation: when WINDOW_SEG_3D is True the
+    # active-segment count is recomputed from the SAME per-q-block window
+    # range the mainloop used (compute_window_segments) instead of the
+    # window-blind full-seq formula.  These constexprs mirror the
+    # mainloop's so the two views CANNOT drift.  Defaults reproduce the
+    # original window-blind behavior byte-for-byte.
+    BLOCK_M: tl.constexpr = 0,
+    num_queries_per_kv: tl.constexpr = 0,
+    SLIDING_WINDOW: tl.constexpr = 0,
+    USE_MM_PREFIX: tl.constexpr = False,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
+    WINDOW_SEG_3D: tl.constexpr = False,
 ):
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
@@ -419,11 +714,38 @@ def reduce_segments(
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
     # number of segments for this particular sequence
-    num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+    if WINDOW_SEG_3D:
+        # Reconstruct the SAME q-block geometry the mainloop used for this
+        # query token, then derive the identical window-relative active
+        # segment count.  cur_start / cur_batch_query_len mirror
+        # resolve_seq_and_query_len; q_block_local_idx is the token's
+        # q-block within its sequence (all tokens in a q-block share it).
+        cur_start = tl.load(query_start_len_ptr + seq_idx)
+        cur_stop = tl.load(query_start_len_ptr + seq_idx + 1)
+        cur_batch_query_len = cur_stop - cur_start
+        q_block_local_idx = (query_token_idx - cur_start) // BLOCK_Q
+        context_len = seq_len - cur_batch_query_len
+        _ws_tile_start, tiles_per_segment, act_num_segments = compute_window_segments(
+            context_len,
+            seq_len,
+            cur_batch_query_len,
+            q_block_local_idx,
+            NUM_SEGMENTS_PER_SEQ,
+            TILE_SIZE,
+            BLOCK_M,
+            BLOCK_Q,
+            num_queries_per_kv,
+            SLIDING_WINDOW,
+            USE_MM_PREFIX,
+            CHUNK_LOOKBACK,
+            CHUNK_SIZE,
+        )
+    else:
+        num_segments = NUM_SEGMENTS_PER_SEQ
+        tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+        # create masks for subsequent loads
+        act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
 
-    # create masks for subsequent loads
-    act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
     segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < tl.full(
         [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
     )
@@ -520,6 +842,13 @@ def unified_attention(
     k_descale,
     v_descale,
     seq_threshold_3D=None,
+    # Max per-sequence query length admitted to the 3D flash-decoding path.
+    # Defaults to 1 (today's pure-decode behavior).  Under MTP/EAGLE
+    # speculative decode this is ``1 + num_speculative_tokens`` so that the
+    # uniform spec-verify decode step (query_len == 1 + num_spec) is still
+    # routed to 3D instead of falling back to the under-occupied 2D split-KV
+    # path.  See ``TritonAttentionMetadataBuilder`` for how it is derived.
+    decode_query_len: int = 1,
     num_par_softmax_segments=None,
     softmax_segm_output=None,
     softmax_segm_max=None,
@@ -578,6 +907,322 @@ def unified_attention(
     BLOCK_M = (
         16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
     )
+
+    # AMMO OP-017: 2D-prefill global-attention launch reroute. Widen
+    # BLOCK_M 16 -> 32 jointly with num_warps=8 for head_size==512 /
+    # num_queries_per_kv==8 / 2D path (gemma-4 global, prefill/chunked-prefill).
+    # Conditions are enforced inline so that:
+    #   * head_size == 512 (global layers; sliding hd256 is unchanged — §6.4)
+    #   * num_queries_per_kv == 8 (the gemma-4 global config; ANY other
+    #     nqpkv<=16 path keeps BLOCK_M=16 byte-for-byte)
+    #   * 2D path only (use_3d == False — i.e. real prefill / chunked-prefill
+    #     with max_seqlen_q > decode_query_len, or fallback 2D split-KV decode)
+    #     — re-uses the same predicate evaluated at the use_3d= line below;
+    #     pre-computed here so BLOCK_Q / total_num_q_blocks observe the
+    #     reroute.  Decode launches (3D, gridZ=16) keep BLOCK_M=16 unchanged.
+    #
+    # Eligibility (selection_rationale §6.8): BLOCK_M is a `tl.constexpr`
+    # template parameter; widening it routes the production shape to a
+    # structurally different compiled Triton kernel (grid (8200,4)->(4104,4),
+    # BLOCK_Q 2->4, acc[32,512] vs [16,512], 8 warps vs 4) — a NEW GPU code
+    # path that does not run in production today.  num_warps=8 is also a
+    # Triton template parameter (re-partitions the MMA tile across the
+    # 8-warp scheduler — different `mma.sync` partitioning vs the 4-warp
+    # baseline) and is NOT the maxnreg launch-time register cap (which
+    # would be config-only and INELIGIBLE).
+    #
+    # Per-CTA fragment dilution mechanism: `acc[BLOCK_M=32, 512]` fp32 spread
+    # across 256 threads (nw=8) holds 64 fp32/thread for acc alone — vs 128
+    # fp32/thread at nw=4, which would spill at the 255-reg cap.  Doubling
+    # threads/CTA absorbs the BLOCK_M doubling (intrinsic +354 reg/thread
+    # working-set growth) WITHOUT spills (measured: 254 regs / 0 spills).
+    #
+    # §6.7 BINDING (correctness-of-dispatch guard): the (num_warps=8,
+    # BLOCK_M=16) cell measured 0.735x — a regression.  num_warps=8 MUST
+    # only be set when BLOCK_M==32 is also set.  The condition below
+    # determines BOTH simultaneously, so they cannot drift apart.  The
+    # launch site reads BLOCK_M and applies num_warps=8 IFF BLOCK_M==32.
+    _op017_2d_prefill_global = (
+        envs.VLLM_OP017
+        and head_size == 512
+        and num_queries_per_kv == 8
+        # Inline re-evaluation of the use_3d -> 2D condition (the canonical
+        # use_3d= computation sits below at line ~747; this predicate is
+        # the same condition negated and is checked again at the canonical
+        # site for the 3D launch path).  We deliberately do NOT depend on
+        # the canonical `use_3d` variable here, because BLOCK_M / BLOCK_Q
+        # / total_num_q_blocks must be set BEFORE use_3d is computed.
+        and (
+            seq_threshold_3D is None
+            or num_par_softmax_segments is None
+            or softmax_segm_output is None
+            or softmax_segm_max is None
+            or softmax_segm_expsum is None
+            or max_seqlen_q > decode_query_len
+            or num_seqs > seq_threshold_3D
+            or is_batch_invariant
+        )
+    )
+    if _op017_2d_prefill_global:
+        BLOCK_M = 32
+
+    # AMMO OP-019: 2D-prefill sliding-window-attention launch reroute. Widen
+    # BLOCK_M 16 -> 64 jointly with num_warps=8 for head_size==256 /
+    # num_queries_per_kv==2 / sliding_window>=0 / 2D path (gemma-4 sliding,
+    # prefill/chunked-prefill).  Predicate is head_size-disjoint from
+    # OP-017's (256 vs 512), so the two cannot both fire on the same launch.
+    # Conditions are enforced inline so that:
+    #   * head_size == 256 (sliding layers; global hd512 is unchanged — OP-017)
+    #   * num_queries_per_kv == 2 (the gemma-4 sliding config; ANY other
+    #     nqpkv path keeps BLOCK_M=16 byte-for-byte)
+    #   * sliding_window >= 0 (sliding-window layers; global window<0 layers
+    #     are unchanged)
+    #   * 2D path only (use_3d == False — i.e. real prefill / chunked-prefill
+    #     with max_seqlen_q > decode_query_len, or fallback 2D split-KV decode)
+    #     — re-uses the same predicate evaluated at the use_3d= line below;
+    #     pre-computed here so BLOCK_Q / total_num_q_blocks observe the
+    #     reroute.  Sliding 3D-decode launches keep BLOCK_M=16 unchanged.
+    #
+    # Eligibility (mirror OP-017 §6.8 cut): BLOCK_M is a `tl.constexpr`
+    # template parameter; widening it routes the production shape to a
+    # structurally different compiled Triton kernel (grid (2056,16,1) ->
+    # (520,16,1), BLOCK_Q 8->32, acc[64,256] vs [16,256], 8 warps vs 4) — a
+    # NEW GPU code path that does not run in production today.  num_warps=8
+    # is also a Triton template parameter (re-partitions the MMA tile across
+    # the 8-warp scheduler — different `mma.sync` partitioning vs the 4-warp
+    # baseline) and is NOT the maxnreg launch-time register cap (which would
+    # be config-only and INELIGIBLE).
+    #
+    # Per-CTA fragment dilution mechanism: at (BLOCK_M=64, num_warps=8) the
+    # acc[64,256] fp32 tile spread across 256 threads holds 64 fp32/thread
+    # for acc — actually CHEAPER in regs (176 measured) than the (64,4) cell
+    # (246 regs) because doubling warps absorbs the BLOCK_M-doubling
+    # working-set growth (no spills at either cell, but headroom is wider at
+    # nw=8).
+    #
+    # BINDING (correctness-of-dispatch guard, mirrors OP-017 §6.7): the
+    # (BLOCK_M=16, num_warps=8) cell measured 0.608x — a regression — same
+    # MMA-fragmentation pathology OP-017 documented for hd512.  num_warps=8
+    # MUST only be set when BLOCK_M==64 is also set.  The condition below
+    # determines BOTH simultaneously, so they cannot drift apart.  The
+    # launch site reads BLOCK_M and applies num_warps=8 IFF BLOCK_M==64 and
+    # the OP-019 predicate is live.
+    _op019_2d_prefill_sliding = (
+        envs.VLLM_OP019
+        and head_size == 256
+        and num_queries_per_kv == 2
+        and window_size[0] >= 0
+        # Inline re-evaluation of the use_3d -> 2D condition (the canonical
+        # use_3d= computation sits below; this predicate is the same
+        # condition negated and is checked again at the canonical site for
+        # the 3D launch path).  We deliberately do NOT depend on the
+        # canonical `use_3d` variable here, because BLOCK_M / BLOCK_Q /
+        # total_num_q_blocks must be set BEFORE use_3d is computed.
+        and (
+            seq_threshold_3D is None
+            or num_par_softmax_segments is None
+            or softmax_segm_output is None
+            or softmax_segm_max is None
+            or softmax_segm_expsum is None
+            or max_seqlen_q > decode_query_len
+            or num_seqs > seq_threshold_3D
+            or is_batch_invariant
+        )
+    )
+    if _op019_2d_prefill_sliding:
+        BLOCK_M = 64
+
+    # AMMO OP-033: TILE_SIZE 32 -> 64 widening on the post-OP-019 sliding-
+    # hd256 2D-prefill kernel_unified_attention launch.  Stacks structurally
+    # on top of OP-019 — strict reslice of OP-019's coverage set: the TILE=64
+    # widening fires IFF VLLM_OP033 is on AND the OP-019 BLOCK_M=64 reroute
+    # is fired (BLOCK_M==64 binding).  This binding ensures TILE=64 only
+    # runs on the post-OP-019 cubin (BLOCK_M=64, num_warps=8, head_size=256,
+    # nqpkv=2, sliding_window>=0, 2D-prefill); a TILE=64 launch on the
+    # pre-OP-019 (BLOCK_M=16, num_warps=4) cell measured 250 regs and is
+    # NOT the supported working point.
+    #
+    # Eligibility (mirror OP-017 §6.8 / OP-019 cuts): TILE_SIZE is a
+    # `tl.constexpr` Triton template parameter; widening it produces a
+    # structurally different compiled cubin (different K-loop iteration count
+    # ~33 -> ~17 per q-block, different SMEM 82,228 B -> 131,636 B / CTA at
+    # num_stages=3, different reg footprint 180 -> 200) — a NEW GPU code
+    # path that does not run in production today.  Same eligibility framing
+    # as OP-017 / OP-019, both shipped on this exact precedent.
+    #
+    # Mechanism: the sliding-window mainloop is a flash-style online-softmax
+    # recurrence; per K-tile iteration the kernel performs `acc = acc *
+    # alpha[:, None]` — the binding latency-path serial recurrence hop.
+    # Doubling TILE_SIZE halves the iteration count (and therefore halves
+    # the recurrence hops) while keeping the MMA work and KV bytes loaded
+    # per q-block invariant (TILE_SIZE × #iters is invariant).  LOSSLESS:
+    # TILE_SIZE does not change tl.dot operand types or softmax precision.
+    #
+    # BINDING (correctness-of-dispatch guard, mirrors OP-017 §6.7 / OP-019):
+    # the (BLOCK_M=16, num_warps=4, TILE=64) cell measures 250 regs and is
+    # NOT the supported working point.  The reroute MUST only fire when
+    # BLOCK_M==64 is also selected.  The condition below ties it to
+    # `_op019_2d_prefill_sliding` (OP-019's predicate that drives BLOCK_M=64).
+    _op033_2d_prefill_sliding_tile64 = (
+        envs.VLLM_OP033 and _op019_2d_prefill_sliding
+    )
+
+    # AMMO OP-017: first-fire / first-passthru log (opt-arm fastpath
+    # evidence).  Memory `[ammo-opt-arm-silently-disabled-masquerades-as-
+    # clean]`: the OP-011 monitors were fooled twice by an opt arm that
+    # silently ran with the optimization OFF — a no-crash, latency-near-
+    # baseline "clean" run.  Emit a single human-grep-able line on first
+    # eligible reroute and on first env-off pass-through so the sweep log
+    # tells us whether the opt arm actually took the new code path.
+    global _OP017_FIRST_FIRE_LOGGED, _OP017_FIRST_PASSTHRU_LOGGED
+    if envs.VLLM_OP017:
+        if _op017_2d_prefill_global and not _OP017_FIRST_FIRE_LOGGED:
+            logger.info(
+                "OP017_ACTIVE BLOCK_M=32 num_warps=8 head_size=%d "
+                "num_queries_per_kv=%d use_3d=False",
+                head_size,
+                num_queries_per_kv,
+            )
+            _OP017_FIRST_FIRE_LOGGED = True
+        # Per-launch coverage tally — gated to avoid per-launch overhead
+        # on the production (env-off) hot path.
+        _is_global = head_size == 512 and num_queries_per_kv == 8
+        # Mirror the use_3d predicate evaluated above (no canonical use_3d
+        # variable available yet — it's set further below).  This is a
+        # tally tag, not a launch decision.
+        _is_2d = (
+            seq_threshold_3D is None
+            or num_par_softmax_segments is None
+            or softmax_segm_output is None
+            or softmax_segm_max is None
+            or softmax_segm_expsum is None
+            or max_seqlen_q > decode_query_len
+            or num_seqs > seq_threshold_3D
+            or is_batch_invariant
+        )
+        if _op017_2d_prefill_global:
+            _op017_dispatch_counters["rerouted_global_2d_prefill"] += 1
+        elif _is_global and not _is_2d:
+            _op017_dispatch_counters["passthru_global_3d_decode"] += 1
+        elif head_size == 256 and _is_2d:
+            _op017_dispatch_counters["passthru_sliding_2d"] += 1
+        elif head_size == 256:
+            _op017_dispatch_counters["passthru_sliding_3d"] += 1
+        elif head_size != 512:
+            _op017_dispatch_counters["passthru_other_head_size"] += 1
+        else:  # head_size==512 but nqpkv != 8
+            _op017_dispatch_counters["passthru_other_nqpkv"] += 1
+    else:
+        _op017_dispatch_counters["env_off_total_launches"] += 1
+
+    # AMMO OP-019: first-fire / first-passthru log + dispatch counter tally
+    # (mirrors the OP-017 block above).  Same opt-arm-fastpath-evidence
+    # rationale per memory `[ammo-opt-arm-silently-disabled-masquerades-as-
+    # clean]`.  Reuses _is_2d computed in the OP-017 block.
+    global _OP019_FIRST_FIRE_LOGGED, _OP019_FIRST_PASSTHRU_LOGGED
+    if envs.VLLM_OP019:
+        if _op019_2d_prefill_sliding and not _OP019_FIRST_FIRE_LOGGED:
+            logger.info(
+                "OP019_ACTIVE BLOCK_M=64 num_warps=8 head_size=%d "
+                "num_queries_per_kv=%d sliding_window=%d use_3d=False",
+                head_size,
+                num_queries_per_kv,
+                window_size[0],
+            )
+            _OP019_FIRST_FIRE_LOGGED = True
+        # Per-launch coverage tally — gated to keep the production
+        # (env-off) hot path overhead-free.  We need a local _is_2d in case
+        # VLLM_OP017 is OFF (the OP-017 block above only computes _is_2d
+        # when its env is ON).
+        _is_2d_op019 = (
+            seq_threshold_3D is None
+            or num_par_softmax_segments is None
+            or softmax_segm_output is None
+            or softmax_segm_max is None
+            or softmax_segm_expsum is None
+            or max_seqlen_q > decode_query_len
+            or num_seqs > seq_threshold_3D
+            or is_batch_invariant
+        )
+        _is_sliding_hd256 = head_size == 256 and window_size[0] >= 0
+        if _op019_2d_prefill_sliding:
+            _op019_dispatch_counters["rerouted_sliding_2d_prefill"] += 1
+        elif _is_sliding_hd256 and num_queries_per_kv == 2 and not _is_2d_op019:
+            _op019_dispatch_counters["passthru_sliding_3d_decode"] += 1
+        elif head_size == 256 and window_size[0] < 0:
+            _op019_dispatch_counters["passthru_sliding_global"] += 1
+        elif head_size == 256 and num_queries_per_kv != 2:
+            _op019_dispatch_counters["passthru_sliding_other_nqpkv"] += 1
+        elif head_size == 512:
+            _op019_dispatch_counters["passthru_global_head_size"] += 1
+        else:
+            _op019_dispatch_counters["passthru_other_head_size"] += 1
+    else:
+        _op019_dispatch_counters["env_off_total_launches"] += 1
+
+    # AMMO OP-033: first-fire log + dispatch counter tally (mirrors OP-019).
+    # Same opt-arm-fastpath-evidence rationale per memory
+    # `[ammo-opt-arm-silently-disabled-masquerades-as-clean]`.  The OP-033
+    # eligibility set is a strict reslice of OP-019's: rerouted_tile64 IFF
+    # the OP-019 BLOCK_M=64 reroute fired AND VLLM_OP033 is on.
+    global _OP033_FIRST_FIRE_LOGGED
+    if envs.VLLM_OP033:
+        if _op033_2d_prefill_sliding_tile64 and not _OP033_FIRST_FIRE_LOGGED:
+            logger.info(
+                "OP033_ACTIVE TILE_SIZE=64 BLOCK_M=64 num_warps=8 "
+                "head_size=%d num_queries_per_kv=%d sliding_window=%d "
+                "use_3d=False",
+                head_size,
+                num_queries_per_kv,
+                window_size[0],
+            )
+            _OP033_FIRST_FIRE_LOGGED = True
+        # Per-launch coverage tally — gated to keep the production
+        # (env-off) hot path overhead-free.  Local _is_2d (independent of
+        # whether VLLM_OP019 is on, since OP-033 may run with OP-019 off in
+        # the misconfiguration bucket "passthru_op019_off_2d_prefill").
+        _is_2d_op033 = (
+            seq_threshold_3D is None
+            or num_par_softmax_segments is None
+            or softmax_segm_output is None
+            or softmax_segm_max is None
+            or softmax_segm_expsum is None
+            or max_seqlen_q > decode_query_len
+            or num_seqs > seq_threshold_3D
+            or is_batch_invariant
+        )
+        _is_sliding_hd256_op033 = head_size == 256 and window_size[0] >= 0
+        if _op033_2d_prefill_sliding_tile64:
+            _op033_dispatch_counters["rerouted_tile64_2d_prefill"] += 1
+        elif (
+            _is_sliding_hd256_op033
+            and num_queries_per_kv == 2
+            and _is_2d_op033
+            and not _op019_2d_prefill_sliding
+        ):
+            # head_size==256 + nqpkv==2 + sliding + 2D, but VLLM_OP019 is OFF
+            # so BLOCK_M stayed at 16 — would have been eligible for TILE=64
+            # but cannot be (binding).  This bucket is non-zero only when
+            # VLLM_OP033 is ON and VLLM_OP019 is OFF — a misconfiguration we
+            # want to catch in the report.
+            _op033_dispatch_counters["passthru_op019_off_2d_prefill"] += 1
+        elif (
+            _is_sliding_hd256_op033
+            and num_queries_per_kv == 2
+            and not _is_2d_op033
+        ):
+            _op033_dispatch_counters["passthru_sliding_3d_decode"] += 1
+        elif head_size == 256 and window_size[0] < 0:
+            _op033_dispatch_counters["passthru_sliding_global"] += 1
+        elif head_size == 256 and num_queries_per_kv != 2:
+            _op033_dispatch_counters["passthru_sliding_other_nqpkv"] += 1
+        elif head_size == 512:
+            _op033_dispatch_counters["passthru_global_head_size"] += 1
+        else:
+            _op033_dispatch_counters["passthru_other_head_size"] += 1
+    else:
+        _op033_dispatch_counters["env_off_total_launches"] += 1
+
     BLOCK_Q = BLOCK_M // num_queries_per_kv
 
     # Ideally we would launch with kernel with:
@@ -610,18 +1255,49 @@ def unified_attention(
 
     # Launch the 2D kernel if
     # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
-    # 2. The batch includes at least one prefill request, or
+    # 2. The batch includes a query longer than the (spec-)decode query length, i.e.
+    #    a real prefill/chunked-prefill request (``max_seqlen_q > decode_query_len``).
+    #    Under MTP spec-decode ``decode_query_len = 1 + num_spec`` (e.g. 5), so a
+    #    uniform spec-verify decode step (max_seqlen_q == 5) is admitted to 3D rather
+    #    than falling to the under-occupied 2D split-KV path.  With the default
+    #    ``decode_query_len == 1`` this disjunct is byte-for-byte the old
+    #    ``max_seqlen_q > 1`` test (backward-safe no-op for non-spec callers), or
     # 3. The number of sequences exceeds the configured threshold, or
     # 4. Batch invariance is enabled
+    #
+    # Sliding-window layers under spec-decode (``decode_query_len > 1`` and
+    # ``window_size[0] >= 0``) ARE admitted to 3D (OP-003): the
+    # window-relative segmentation (``WINDOW_SEG_3D`` below) tiles the
+    # segments over the sliding window's tile range instead of the full
+    # sequence, so segment parallelism is not collapsed.  Without
+    # WINDOW_SEG_3D the window-blind segmentation would mis-segment sliding
+    # layers; the flag and the matched ``reduce_segments`` recompute keep
+    # the mainloop and reduction consistent.  ``mm_prefix`` (bidirectional)
+    # sliding layers are NOT window-segmented (the window pruning is
+    # disabled for them in the helpers), so they fall back to full-seq 3D.
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
+        or max_seqlen_q > decode_query_len
         or num_seqs > seq_threshold_3D
         or is_batch_invariant
+    )
+
+    # OP-003: window-relative 3D segmentation applies only to sliding-window
+    # layers in the spec-decode regime.  Global layers (window_size[0] < 0)
+    # and pure-decode callers (decode_query_len == 1) keep the original
+    # full-sequence segmentation byte-for-byte.  mm_prefix sliding layers are
+    # excluded (window tile-pruning is a no-op under USE_MM_PREFIX, so the
+    # window range would equal the full sequence and segmentation must stay
+    # full-seq to match).
+    window_seg_3d = (
+        use_3d
+        and decode_query_len > 1
+        and window_size[0] >= 0
+        and not use_mm_prefix
     )
 
     # The kernel signature is the same for 2D and 3D — only the launch
@@ -657,6 +1333,35 @@ def unified_attention(
     else:
         grid = (total_num_q_blocks, num_kv_heads, num_par_softmax_segments)
         tile_size = TILE_SIZE_DECODE
+
+    # AMMO OP-033: TILE_SIZE 32 -> 64 widening on the post-OP-019 sliding-
+    # hd256 2D-prefill kernel_unified_attention launch.  Override tile_size
+    # at the launch site (binds to BLOCK_M==64 + 2D-prefill predicate that
+    # OP-019 already enforces).  Disjoint from the 3D path (use_3d=True)
+    # and from non-OP-019 launches (BLOCK_M=16): only the (BLOCK_M=64,
+    # num_warps=8, sliding-hd256, 2D-prefill) cubin gets TILE=64.
+    if not use_3d and BLOCK_M == 64 and _op033_2d_prefill_sliding_tile64:
+        tile_size = 64
+
+    # AMMO OP-017 / OP-019: gate num_warps=8 on the matched BLOCK_M widening
+    # (BINDING).
+    #   - OP-017 §6.7: (num_warps=8, BLOCK_M=16) measured 0.735x for hd512
+    #     2D-prefill global => num_warps=8 MUST be conditioned on BLOCK_M==32
+    #     AND _op017_2d_prefill_global.
+    #   - OP-019 (mirrors OP-017 §6.7): (num_warps=8, BLOCK_M=16) measured
+    #     0.608x for hd256 2D-prefill sliding => num_warps=8 MUST be
+    #     conditioned on BLOCK_M==64 AND _op019_2d_prefill_sliding.
+    # The two predicates are head_size-disjoint (512 vs 256) so cannot both
+    # fire on the same launch.  Reading the actual BLOCK_M value here ensures
+    # the parameters cannot drift apart even under future predicate edits.
+    # Without this kwarg, Triton uses its JIT default (4 warps), which is the
+    # production baseline for all other launches (decode 3D, any 2D where
+    # BLOCK_M stayed at 16).
+    _op017_kernel_kwargs: dict[str, Any] = {}
+    if BLOCK_M == 32 and _op017_2d_prefill_global:
+        _op017_kernel_kwargs["num_warps"] = 8
+    elif BLOCK_M == 64 and _op019_2d_prefill_sliding:
+        _op017_kernel_kwargs["num_warps"] = 8
 
     kernel_unified_attention[grid](
         output_ptr=out,
@@ -723,6 +1428,8 @@ def unified_attention(
         KV_QUANT_MODE=kv_quant_mode,
         CHUNK_LOOKBACK=chunk_lookback,
         CHUNK_SIZE=chunk_size,
+        WINDOW_SEG_3D=window_seg_3d,
+        **_op017_kernel_kwargs,
     )
 
     if use_3d:
@@ -745,4 +1452,13 @@ def unified_attention(
             BLOCK_Q=BLOCK_Q,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
             USE_FP8=output_scale is not None,
+            # OP-003: mirror the mainloop's window-segmentation inputs so
+            # reduce_segments recomputes the IDENTICAL active-segment count.
+            BLOCK_M=BLOCK_M,
+            num_queries_per_kv=num_queries_per_kv,
+            SLIDING_WINDOW=(1 + window_size[0]),
+            USE_MM_PREFIX=use_mm_prefix,
+            CHUNK_LOOKBACK=chunk_lookback,
+            CHUNK_SIZE=chunk_size,
+            WINDOW_SEG_3D=window_seg_3d,
         )


### PR DESCRIPTION
## Summary

This PR adds six opt-in attention and quantized-GEMM optimizations for `nvidia/gemma-4-31B-it-NVFP4` on NVIDIA B200 (Blackwell, SM100, CC 10.0): TP=1, NVFP4 MLP weights, bf16 attention, FP8 KV cache, and speculative decoding (MTP, 4 draft tokens, draft model `google/gemma-4-31B-it-assistant`).

**The default path is unchanged.** Five of the six optimizations are behind environment flags that default to off; the sixth is always compiled in but is a strict no-op outside the speculative-decode path it targets. With no flags set, the decode and prefill paths are byte-for-byte identical to vLLM 0.21.0.

## Optimizations

- **Speculative-decode flash-decoding** (always-on, lossless, no flag). The Triton unified-attention 3D split-KV (flash-decoding) path was gated to `max_seqlen_q == 1`, so every speculative-decode verify step (`max_seqlen_q = 5`) fell back to a low-occupancy 2D kernel (12 CTAs on 148 SMs at batch size 1). This admits the spec-decode step into the 3D path and adds sliding-window-relative segmentation so local-attention layers reach it too. It is a strict no-op for pure decode (`max_seqlen_q == 1`) and for `num_seqs > 8`, so non-spec callers are unaffected.
  - Dominant decode win: **+18.5% end-to-end at batch size 1** (decode phase −82%); neutral at batch size 8.
- **FP8 attention-projection GEMMs** (`VLLM_OP004_FP8_ATTN`, lossy). The NVFP4 checkpoint keeps all 60 `self_attn` QKV/O projections in bf16. This routes them through FP8-e4m3 (per-channel weight, per-token dynamic activation) via SM100-native `cutlass_scaled_mm`, roughly halving weight bytes in the bandwidth-bound decode regime. `lm_head` and the vision tower stay bf16.
  - **+1.7% end-to-end at batch size 8.**
- **Global head-dim-512 prefill kernel retune** (`VLLM_OP017`, lossless). Widens the global hd512 2D-prefill Triton kernel (`BLOCK_M 16→32`, `num_warps 4→8`).
  - Kernel speedup **1.32–1.34×**.
- **Sliding-window head-dim-256 prefill kernel retune** (`VLLM_OP019`, lossless). Widens the sliding-window hd256 2D-prefill kernel (`BLOCK_M 16→64`, `num_warps 4→8`).
  - Isolated kernel speedup **1.68×**; **+9.6% end-to-end at batch size 8**.
- **Sliding-window head-dim-256 prefill tile widening** (`VLLM_OP033`, lossless). Stacks `TILE_SIZE 32→64` on the reroute above.
  - **+0.8% end-to-end at batch size 8.**
- **Per-shape NVFP4 GEMM dispatch** (`VLLM_OP039`, `VLLM_OP039_M_THRESHOLD`, lossless). Routes the NVFP4 `gate_up_proj`/`down_proj` GEMMs by M: FlashInfer/cuDNN at prefill shapes (M ≥ threshold, default 1024), in-tree CUTLASS at decode shapes.
  - **+0.3% end-to-end at batch size 8.**

## Fixed-batch latency

`vllm bench latency`, `--input-len 27000 --output-len 150`, MTP 4 draft tokens, TP=1.

| Optimization | Env flag | Lossless | Effect |
|---|---|---|---|
| Speculative-decode flash-decoding | always-on (guarded) | yes | +18.5% E2E @ BS1 (decode −82%); neutral @ BS8 |
| FP8 attn-projection GEMM | `VLLM_OP004_FP8_ATTN` | no (FP8) | +1.7% E2E @ BS8 |
| Global hd512 prefill retune | `VLLM_OP017` | yes | 1.32–1.34× kernel |
| Sliding hd256 prefill retune | `VLLM_OP019` | yes | 1.68× kernel; +9.6% E2E @ BS8 |
| Sliding hd256 tile widening | `VLLM_OP033` | yes | +0.8% E2E @ BS8 |
| Per-shape NVFP4 GEMM dispatch | `VLLM_OP039` | yes | +0.3% E2E @ BS8 |

Stacked, the flag-on build is **~1.48× faster at BS1 and ~1.41× at BS8** versus the starting point. Measured on B200; the always-on and FP8 tracks were first measured on the related B300 (also SM100). BS32 has no stable baseline at this input length (OOM / timeout) and is not reported.

## Per-stream latency under a sustained agentic load

Beyond the fixed-batch sweep, the stack was evaluated under a sustained multi-turn agentic workload at fixed concurrency — long shared ~27K-token prefixes, short ~150-token generations, many concurrent streams, speculative decoding active. This is the regime the flash-decoding change targets.

- **Hardware:** B200 (SM100), TP=1.
- **Workload:** synthetic agentic trace (128 trajectories / 512 turns, mean input ~27K tokens, median output ~150), greedy + `--ignore-eos` for determinism, 600 s phases with 60 s warmup.
- **A/B:** OFF = unpatched base build; ON = the optimized build. Identical harness, dataset, and server config; zero failed requests in either leg.

| Users | p50 speed OFF→ON (tok/s) | Δ p50 | p25 speed OFF→ON (tok/s) | Δ p25 | Δ throughput | P95 TTFT OFF→ON |
|--:|--|--|--|--|--|--|
| 1 | 76.6 → 234.8 | +206% | 37.5 → 199.7 | +433% | +11% | 33.0 → 32.1 s |
| 4 | 15.5 → 40.0 | +158% | 6.8 → 9.75 | +43% | −8% | 57.4 → 60.6 s |
| 8 | 4.8 → 12.9 | +170% | 2.8 → 4.59 | +64% | +16% | 40.6 → 64.4 s |
| 16 | 3.15 → 4.07 | +29% | 2.2 → 2.73 | +24% | +45% | 56.6 → 51.5 s |

- Typical-request (p50) output speed improves **1.3×–3.1×**, largest at low concurrency and shrinking toward parity as the GPU fills — the signature of the flash-decoding path firing at low batch and reverting to the 2D grid under load.
- At a single stream, decode rises from ~77 to ~235 tok/s — roughly 15% → 42% of the model's memory-bandwidth roofline.
- This is a **per-stream latency** result, not a throughput/capacity claim: aggregate throughput is roughly flat, and no latency-SLO tier passes in either leg (P95 TTFT 32–64 s, since ~144K-token prefills serialize on one GPU). A meaningful capacity number needs ≥2 GPUs or prefill-aware admission.

*The per-stream win was independently re-derived from the raw per-request records at ~0% drift and reproduces across runs. The table was captured on an earlier version of this stack, but its dominant driver — the always-on flash-decoding path — is unchanged here, so it remains representative.*

## Correctness

GSM8K, greedy decode, 1319 questions, 1.0pp tolerance (a change ships only if `opt ≥ baseline − 1.0pp`). Speculative greedy decode is not bit-reproducible per question, so small symmetric churn is expected; the gate is no >1.0pp regression.

- The five lossless optimizations are bit-identical at the kernel level (max abs error ≤ 1.95e-3, far inside the 1e-2 budget) and show no GSM8K change — the retunes alter kernel configuration, not arithmetic.
- The FP8 attention-projection GEMM is lossy by design and clears the accuracy gate at **60.4%** against a 54.8% threshold.

## Changes

Python-only; an editable install picks them up with no `csrc/` rebuild. Rebuilt cleanly from vLLM 0.21.0. **8 files, +1623 / −34.**

- `triton_unified_attention.py`, `triton_attention_helpers.py`, `triton_attn.py` — flash-decoding admission + prefill-kernel retunes
- `op004_fp8_attn.py` (new) + `modelopt.py` — FP8 attention-projection GEMMs
- `nvfp4/op039_shape_routed.py` (new) + `kernels/linear/__init__.py` — per-shape NVFP4 dispatch
- `envs.py` — the six flags (all default off)

## AI-assisted contribution

These optimizations were generated by an automated, gated kernel-optimization process driving Claude (Anthropic), with human review. Every shipped change passed kernel-level correctness, GSM8K accuracy, and end-to-end latency checks; all numbers were measured on real Blackwell (SM100) hardware under CUDA graphs + `torch.compile`. With the flags unset the default path is unchanged from vLLM 0.21.0.
