### PR TITLE
[Kernel] Two-stream MLA/MoE pipelining + MoE FP4 preamble fusion for Kimi-K2.6-NVFP4 (B300, env-gated, default-off)

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -53,6 +53,11 @@ def create_fp4_scale_tensor(
 
     block_size = 16
     if is_sf_swizzled_layout:
+        # Swizzled (non-TRTLLM) path: `cvt_fp16_to_fp4` iterates to the
+        # padded `sf_m` so every padded address is initialized; however
+        # the int32 packing (4 fp8 scales per int32) means partial-int32
+        # writes would mix tile-undefined bytes if the buffer were
+        # uninitialized. Keep zero-init here for safety.
         rounded_m = round_up(m, 128)
         scale_n = n // block_size
         rounded_n = round_up(scale_n, 4)
@@ -60,6 +65,16 @@ def create_fp4_scale_tensor(
             (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
         )
     else:
+        # Non-swizzled (sf_major / FlashInfer-TRTLLM) path: the
+        # `cvt_fp16_to_fp4_sf_major` kernel writes every scale-factor
+        # address (see csrc/libtorch_stable/quantization/fp4/
+        # nvfp4_quant_kernels.cu:132-134), so the FillFunctor pre-zero
+        # is redundant. AMMO OP-003 elides the launch when the
+        # VLLM_OP003_PREAMBLE_FUSION gate is set.
+        if envs.VLLM_OP003_PREAMBLE_FUSION:
+            return torch.empty(
+                (m, n // block_size), device=device, dtype=torch.uint8
+            )
         return torch.zeros((m, n // block_size), device=device, dtype=torch.uint8)
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -177,6 +177,9 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_FP8: bool = False
     VLLM_USE_FLASHINFER_MOE_FP4: bool = False
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
+    VLLM_OP003_PREAMBLE_FUSION: bool = False
+    VLLM_OP010_MLA_TWO_STREAM: bool = False
+    VLLM_OP014_MOE_TWO_STREAM: bool = False
     VLLM_FLASHINFER_MOE_BACKEND: Literal["throughput", "latency", "masked_gemm"] = (
         "latency"
     )
@@ -220,6 +223,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
     VLLM_ALLREDUCE_USE_FLASHINFER: bool = False
+    VLLM_OP013_LAMPORT_AR: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
     VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT: bool = False
@@ -1310,6 +1314,46 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))
     ),
+    # AMMO OP-003: enable MoE FP4 preamble fusion. Eliminates two
+    # redundant per-MoE-layer kernel launches when the FlashInfer
+    # TRTLLM MoE backend is selected:
+    #   1. The FillFunctor (torch.zeros) preceding cvt_fp16_to_fp4_sf_major
+    #      — cvt overwrites every scale-factor address in the sf_major
+    #        (non-swizzled) layout, so torch.empty is safe.
+    #   2. The per-layer e_score_correction_bias.to(bfloat16) cast — the
+    #      bias is a constant nn.Parameter and can be pre-cast at module
+    #        init time (mirrors the existing ROCm pattern).
+    "VLLM_OP003_PREAMBLE_FUSION": lambda: bool(
+        int(os.getenv("VLLM_OP003_PREAMBLE_FUSION", "0"))
+    ),
+    # AMMO OP-010: enable two-stream MLA decode pipelining for the standard
+    # MLA path (vllm/model_executor/layers/mla.py). When set, the MLA wrapper
+    # creates an auxiliary CUDA stream and dispatches the q-path
+    # (q_a_layernorm → q_b_proj → q-side RoPE) and the kv-path
+    # (kv_lora.split → kv_a_layernorm → k-side RoPE) onto two streams,
+    # synchronized via CUDA events. The two paths are structurally
+    # independent between fused_qkv_a_proj and the attention kernel call,
+    # which lets the GPU overlap their execution. This mirrors the
+    # production-proven pattern in deepseek_v4_attention.py:368-386 and
+    # uses vllm.utils.multi_stream_utils.maybe_execute_in_parallel under
+    # the hood.
+    "VLLM_OP010_MLA_TWO_STREAM": lambda: bool(
+        int(os.getenv("VLLM_OP010_MLA_TWO_STREAM", "0"))
+    ),
+    # AMMO OP-014: Replace the framework's `Stream.wait_stream`-based
+    # MoE shared/routed expert overlap (`SharedExperts._run_in_aux_stream`)
+    # with the OP-010-style `torch.cuda.Event` record/wait pattern so that
+    # the shared-expert NVJet GEMMs and routed-expert FP4 BMMs actually
+    # run concurrently under CUDA graph capture. The framework's
+    # MULTI_STREAM_OVERLAPPED path silently degenerates to sequential
+    # under CUDA-graph capture (proven by R5 nsys: ALL MoE kernels on the
+    # same streamId), while the event-based pattern parks shared-expert
+    # work on a side-stream just like OP-010 parks `concat_and_cache_mla`.
+    # When unset (default), behaviour is bit-identical to the existing
+    # framework path.
+    "VLLM_OP014_MOE_TWO_STREAM": lambda: bool(
+        int(os.getenv("VLLM_OP014_MOE_TWO_STREAM", "0"))
+    ),
     # If set to 1, use the FlashInfer
     # MXFP8 (activation) x MXFP4 (weight) MoE backend.
     "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8": lambda: bool(
@@ -1552,6 +1596,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use FlashInfer allreduce
     "VLLM_ALLREDUCE_USE_FLASHINFER": lambda: bool(
         int(os.getenv("VLLM_ALLREDUCE_USE_FLASHINFER", "0"))
+    ),
+    # OP-013: enable the AllReduceLamportReplacementPass that rewrites
+    # standalone AllReduce sites in the compiled decode graph to dispatch
+    # through FlashInfer Lamport oneshot (instead of NCCL ring_LL).
+    # Default off; enable for evaluation only.
+    "VLLM_OP013_LAMPORT_AR": lambda: bool(
+        int(os.getenv("VLLM_OP013_LAMPORT_AR", "0"))
     ),
     # Experimental: use this to enable MCP tool calling for non harmony models
     "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": lambda: bool(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -244,6 +244,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer, has_nvidia_artifactory
 from vllm.utils.math_utils import cdiv, round_down
+from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -486,6 +487,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and self.kv_b_proj.weight.dtype == torch.bfloat16
         )
 
+        # AMMO OP-010: optional auxiliary CUDA stream + event pair used to
+        # overlap the kv-path tail (`do_kv_cache_update`, which executes
+        # `concat_and_cache_mla`) with the q-path head of `forward_impl`
+        # (`W_UK_T` BMM). Initialized lazily by the parent
+        # `MultiHeadLatentAttentionWrapper` via `set_aux_stream(...)` when
+        # `VLLM_OP010_MLA_TWO_STREAM=1`. When unset, the dispatch falls
+        # through to the standard sequential path with no behavioral
+        # change.
+        self._op010_aux_stream: torch.cuda.Stream | None = None
+        self._op010_events: tuple[torch.cuda.Event, torch.cuda.Event] | None = None
+
         # Attributes for forward_impl method
         self._vllm_config = get_current_vllm_config()
         self._chunked_prefill_workspace_size: int | None = None
@@ -509,6 +521,24 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
             )
         return self._chunked_prefill_workspace_size
+
+    def set_aux_stream(
+        self,
+        aux_stream: torch.cuda.Stream,
+        events: tuple[torch.cuda.Event, torch.cuda.Event],
+    ) -> None:
+        """AMMO OP-010 hook: install an auxiliary CUDA stream + event pair.
+
+        The wrapper layer (`MultiHeadLatentAttentionWrapper`) calls this
+        when `VLLM_OP010_MLA_TWO_STREAM=1`. With the stream installed, the
+        direct-call path of `forward()` overlaps `do_kv_cache_update`
+        (concat_and_cache_mla) on the auxiliary stream with the start of
+        `forward_impl` (W_UK_T BMM) on the default stream. Reuses the same
+        stream + events as the wrapper so that we don't duplicate stream
+        objects per-MLA-layer.
+        """
+        self._op010_aux_stream = aux_stream
+        self._op010_events = events
 
     def forward(
         self,
@@ -543,23 +573,78 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             assert isinstance(slot_mapping, dict), (
                 f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
             )
-            self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
-                kv_c_normed,
-                k_pe,
-                self_kv_cache,
-                slot_mapping.get(self.layer_name),
-                self.kv_cache_dtype,
-                self._k_scale,
-            )
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
-            self.forward_impl(
-                q,
-                kv_c_normed,
-                k_pe,
-                self_kv_cache,
-                attn_metadata,
-                output=output,
-            )
+
+            # AMMO OP-010: when an auxiliary CUDA stream has been installed
+            # by the wrapper layer (via `set_aux_stream`), overlap
+            # `do_kv_cache_update` (concat_and_cache_mla, ~2.4 µs/layer on
+            # B300) with the q-path head of `forward_impl` (the `W_UK_T`
+            # BMM, ~6.5 µs/layer). Synchronization protocol:
+            #   1. Default stream records `kv_cache_pre_event` to mark the
+            #      point at which `kv_c_normed` and `k_pe` are produced.
+            #   2. Aux stream waits for the pre-event, then enqueues
+            #      `do_kv_cache_update`, then records
+            #      `kv_cache_ready_event`.
+            #   3. Default stream calls `forward_impl(...,
+            #      kv_cache_ready_event=...)`. The W_UK_T BMM and all
+            #      cache-independent prep run immediately, in parallel
+            #      with the cache write. Just before `forward_mqa`
+            #      launches the attention kernel (which reads the cache),
+            #      `forward_impl` waits on `kv_cache_ready_event` so the
+            #      attention kernel sees the post-write cache.
+            # When the auxiliary stream is unavailable, fall through to
+            # the original sequential dispatch with no behavioral change.
+            if (
+                self._op010_aux_stream is not None
+                and self._op010_events is not None
+            ):
+                event_pre_kv, event_kv_ready = self._op010_events
+                # Pre-event: a barrier on the default stream so the aux
+                # stream waits for the producer of `kv_c_normed` / `k_pe`
+                # before reading them.
+                event_pre_kv.record()
+                with torch.cuda.stream(self._op010_aux_stream):
+                    event_pre_kv.wait()
+                    self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
+                        kv_c_normed,
+                        k_pe,
+                        self_kv_cache,
+                        slot_mapping.get(self.layer_name),
+                        self.kv_cache_dtype,
+                        self._k_scale,
+                    )
+                    event_kv_ready.record()
+                # Default stream continues with W_UK_T BMM + attention.
+                # `forward_impl` waits on `event_kv_ready` immediately
+                # before the attention kernel call so the cache write is
+                # visible to `forward_mqa` while the BMM still overlaps
+                # the cache write in time.
+                self.forward_impl(
+                    q,
+                    kv_c_normed,
+                    k_pe,
+                    self_kv_cache,
+                    attn_metadata,
+                    output=output,
+                    kv_cache_ready_event=event_kv_ready,
+                )
+            else:
+                self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
+                    kv_c_normed,
+                    k_pe,
+                    self_kv_cache,
+                    slot_mapping.get(self.layer_name),
+                    self.kv_cache_dtype,
+                    self._k_scale,
+                )
+                self.forward_impl(
+                    q,
+                    kv_c_normed,
+                    k_pe,
+                    self_kv_cache,
+                    attn_metadata,
+                    output=output,
+                )
             return output
         else:
             encoded = _encode_layer_name(self.layer_name)
@@ -595,6 +680,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         quant_scale_ue8m0: bool | None = None,
         quant_col_major: bool | None = None,
         quant_tma_aligned: bool | None = None,
+        kv_cache_ready_event: torch.cuda.Event | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
 
@@ -669,6 +755,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             num_mha_tokens = q.size(0) - num_mqa_tokens
 
         if num_mha_tokens > 0:
+            # AMMO OP-010: `forward_mha` (prefill) reads `kv_cache`, so we
+            # must synchronize with the aux stream's cache write here.
+            # MHA workloads do not benefit from W_UK_T BMM overlap (the
+            # W_UK_T BMM is decode-only, inside the `num_mqa_tokens > 0`
+            # block), so waiting before MHA does not cost any overlap.
+            if kv_cache_ready_event is not None:
+                kv_cache_ready_event.wait()
             self.impl.forward_mha(  # type: ignore[attr-defined]
                 q[num_mqa_tokens:],
                 k_c_normed[num_mqa_tokens:],
@@ -748,6 +841,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_q = torch.cat(mqa_q, dim=-1)
                 # mqa_q do allgather in head dim.
                 mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
+
+            # AMMO OP-010: synchronize the default stream with the aux
+            # stream's `do_kv_cache_update` immediately before the
+            # decode attention kernel reads `kv_cache`. All cache-
+            # independent prep above (W_UK_T BMM, the FP8/FP4 quant
+            # variants, the optional DCP all-gather) has already run on
+            # the default stream concurrently with the cache write — that
+            # is the overlap that produces the gain. Waiting here
+            # guarantees the cache write is visible to `forward_mqa`.
+            # When `kv_cache_ready_event` is None, this is a no-op.
+            if kv_cache_ready_event is not None:
+                kv_cache_ready_event.wait()
 
             # call decode attn
             if not is_sparse_impl:
@@ -1014,14 +1119,42 @@ def unified_mla_kv_cache_update(
     )
     layer_slot_mapping = slot_mapping.get(layer_name)
     if layer_slot_mapping is not None:
-        attn_layer.impl.do_kv_cache_update(
-            kv_c_normed,
-            k_pe,
-            kv_cache,
-            layer_slot_mapping,
-            kv_cache_dtype,
-            k_scale,
-        )
+        # AMMO OP-010: when an auxiliary CUDA stream has been installed
+        # by the wrapper layer (`MultiHeadLatentAttentionWrapper`),
+        # dispatch `do_kv_cache_update` (concat_and_cache_mla, ~2.4 µs)
+        # onto the aux stream so it overlaps with the W_UK_T BMM that
+        # `unified_mla_attention_with_output` runs on the default stream.
+        # Synchronization protocol mirrors the direct-call path in
+        # `MLAAttention.forward`: a pre-event ensures the aux stream
+        # waits for `kv_c_normed` / `k_pe` to be produced; a ready-event
+        # is recorded after the cache write and is awaited on the
+        # default stream just before the attention kernel reads
+        # `kv_cache`.
+        aux_stream = getattr(attn_layer, "_op010_aux_stream", None)
+        events = getattr(attn_layer, "_op010_events", None)
+        if aux_stream is not None and events is not None:
+            event_pre_kv, event_kv_ready = events
+            event_pre_kv.record()
+            with torch.cuda.stream(aux_stream):
+                event_pre_kv.wait()
+                attn_layer.impl.do_kv_cache_update(
+                    kv_c_normed,
+                    k_pe,
+                    kv_cache,
+                    layer_slot_mapping,
+                    kv_cache_dtype,
+                    k_scale,
+                )
+                event_kv_ready.record()
+        else:
+            attn_layer.impl.do_kv_cache_update(
+                kv_c_normed,
+                k_pe,
+                kv_cache,
+                layer_slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+            )
 
     return torch.empty(0, device=kv_c_normed.device, dtype=kv_c_normed.dtype)
 
@@ -1064,6 +1197,18 @@ def unified_mla_attention_with_output(
     del kv_cache_dummy_dep
     layer_name = _resolve_layer_name(layer_name)
     attn_metadata, layer, kv_cache, _ = get_attention_context(layer_name)
+    # AMMO OP-010: pull the `kv_cache_ready_event` recorded by the
+    # paired `unified_mla_kv_cache_update` op so `forward_impl` can wait
+    # on it just before the attention kernel reads `kv_cache`. The W_UK_T
+    # BMM and other cache-independent prep inside `forward_impl` run on
+    # the default stream concurrently with the cache write — that is the
+    # overlap that produces the gain. When the aux stream is unset
+    # (default), `events` is None and the wait is skipped.
+    events = getattr(layer, "_op010_events", None)
+    aux_stream = getattr(layer, "_op010_aux_stream", None)
+    kv_cache_ready_event: torch.cuda.Event | None = None
+    if aux_stream is not None and events is not None:
+        kv_cache_ready_event = events[1]
     layer.forward_impl(
         q,
         kv_c_normed,
@@ -1077,6 +1222,7 @@ def unified_mla_attention_with_output(
         quant_scale_ue8m0=quant_scale_ue8m0,
         quant_col_major=quant_col_major,
         quant_tma_aligned=quant_tma_aligned,
+        kv_cache_ready_event=kv_cache_ready_event,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -451,6 +451,33 @@ class MoERunner(MoERunnerInterface):
             shared_experts_input, SharedExpertsOrder.NO_OVERLAP
         )
 
+        # AMMO OP-014: When the event-based two-stream overlap is active
+        # (`VLLM_OP014_MOE_TWO_STREAM=1`) AND the runtime configuration
+        # selects MULTI_STREAM_OVERLAPPED for this input, enqueue the
+        # shared-expert launch onto the aux stream BEFORE the
+        # routed-expert kernels are enqueued on the default stream. This
+        # widens the overlap window so the routed FP4 BMM (the heavy
+        # kernel chain) runs concurrently with the small shared-expert
+        # NVJet GEMMs on the GPU under CUDA graph capture. With the
+        # legacy `wait_stream` path we keep the original ordering
+        # (launch shared AFTER the routed kernels) for bit-identical
+        # fallback behaviour.
+        shared_started_early = False
+        if (
+            self._shared_experts is not None
+            and shared_experts_input is not None
+            and self._shared_experts._use_events
+            and self._shared_experts._determine_shared_experts_order(
+                shared_experts_input
+            )
+            == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+        ):
+            self._maybe_apply_shared_experts(
+                shared_experts_input,
+                SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+            )
+            shared_started_early = True
+
         if self.quant_method.is_monolithic:
             fused_out = self.quant_method.apply_monolithic(
                 layer=layer,
@@ -475,10 +502,20 @@ class MoERunner(MoERunnerInterface):
                 shared_experts_input=shared_experts_input,
             )
 
-        self._maybe_apply_shared_experts(
-            shared_experts_input,
-            SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
-        )
+        if not shared_started_early:
+            # Legacy `wait_stream`-based path: launch shared experts AFTER
+            # the routed-expert kernels (matches pre-OP-014 ordering).
+            self._maybe_apply_shared_experts(
+                shared_experts_input,
+                SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+            )
+        else:
+            # AMMO OP-014: Default stream waits on the shared-expert
+            # `post_event` before the caller reads `shared_output`. This
+            # join captures the full routed-expert work as parallel with
+            # the shared-expert work in the CUDA graph DAG.
+            assert self._shared_experts is not None
+            self._shared_experts.join_event_overlap()
 
         return (
             self._shared_experts.output if self._shared_experts is not None else None,

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -78,6 +78,36 @@ class SharedExperts:
             if self._stream is not None:
                 logger.debug_once("Enabled separate cuda stream for MoE shared_experts")
 
+        # AMMO OP-014: Replace the framework's `Stream.wait_stream`-based
+        # shared/routed-expert overlap with the OP-010-style
+        # `torch.cuda.Event` record/wait pattern under CUDA graph capture.
+        # The framework's existing `wait_stream`-based path silently
+        # degenerates to sequential under CUDA-graph capture (proven by
+        # R5 nsys: ALL MoE kernels on the same streamId), while the
+        # event-based pattern actually parks shared-expert work on a
+        # side-stream concurrent with the routed-expert FP4 BMM. When
+        # the env var is unset (default), `_use_events` is False and
+        # behaviour is bit-identical to the original framework path.
+        self._use_events: bool = (
+            envs.VLLM_OP014_MOE_TWO_STREAM
+            and self._stream is not None
+            and current_platform.is_cuda()
+        )
+        # Two pre/post event pairs -- indexed by ubatch id (DBO can run
+        # two ubatches in parallel; only index 0 is used when DBO is
+        # disabled).
+        self._events: list[tuple[torch.cuda.Event, torch.cuda.Event] | None] = [
+            None,
+            None,
+        ]
+        if self._use_events:
+            self._events[0] = (torch.cuda.Event(), torch.cuda.Event())
+            if enable_dbo:
+                self._events[1] = (torch.cuda.Event(), torch.cuda.Event())
+            logger.debug_once(
+                "AMMO OP-014: enabled event-based MoE shared/routed two-stream overlap"
+            )
+
     @property
     def _disable_shared_experts_overlap(self) -> bool:
         # Disable shared expert overlap if:
@@ -128,6 +158,16 @@ class SharedExperts:
             # because we synch the streams before using shared_output.
             shared_experts_input.record_stream(self._stream)
 
+            if self._use_events:
+                # AMMO OP-014: Defer the cross-stream sync to
+                # `_run_in_aux_stream`, where we use the OP-010-style
+                # `torch.cuda.Event` record/wait pair. `wait_stream`
+                # collapses to sequential under CUDA-graph capture; we
+                # avoid recording any `wait_stream` edge here so the
+                # captured graph can express true parallelism between
+                # the shared-expert and routed-expert paths.
+                return
+
             # Mark sync start point for the aux stream since we will
             # run in parallel with router/gate.
             self._stream.wait_stream(current_stream())
@@ -138,12 +178,68 @@ class SharedExperts:
     ) -> torch.Tensor:
         # TODO: assert that maybe_sync_shared_experts_stream has been called.
 
+        if self._use_events:
+            # AMMO OP-014: Event-based two-stream pattern (mirrors
+            # OP-010's `unified_mla_kv_cache_update` /
+            # `unified_mla_attention_with_output` flow). Under CUDA
+            # graph capture, `Stream.wait_stream(other)` lowers to a
+            # plain barrier on the captured graph, serializing both
+            # streams (R5 nsys confirms ALL MoE kernels land on the
+            # same streamId). `Event.record()` / `Event.wait()`
+            # captures inter-stream dependencies as DAG edges, which
+            # CUDA replay honours as real parallelism on the GPU.
+            #
+            # Protocol:
+            #   1. Record `pre_event` on the default stream so the aux
+            #      stream waits for the producer of
+            #      `shared_experts_input` (e.g. the layernorm + clone)
+            #      before reading it.
+            #   2. On the aux stream, wait for `pre_event`, run the
+            #      shared-expert layer (BF16 NVJet GEMMs on Kimi-K2.6),
+            #      then record `post_event`.
+            #   3. The default stream proceeds with the routed-expert
+            #      FP4 BMMs concurrently. The join (`post_event.wait()`
+            #      on the default stream) is performed by the caller
+            #      via `join_event_overlap()` after `apply_monolithic`
+            #      / `apply` returns, just before the
+            #      `shared_output + fused_output` add.
+            assert self._events[self._output_idx] is not None
+            pre_event, post_event = self._events[self._output_idx]
+            pre_event.record()
+            with torch.cuda.stream(self._stream):
+                pre_event.wait()
+                output = self._layer(shared_experts_input)
+                post_event.record()
+            return output
+
         # Run shared experts in parallel on a separate stream.
         with torch.cuda.stream(self._stream):
             output = self._layer(shared_experts_input)
         current_stream().wait_stream(self._stream)
 
         return output
+
+    def join_event_overlap(self) -> None:
+        """AMMO OP-014: Join the event-based shared-expert overlap.
+
+        When the event-based pattern (`_use_events == True`) was used
+        to launch the shared-expert layer onto the aux stream, the
+        default stream must wait on the `post_event` before reading
+        `self.output`. This is invoked by `MoERunner._apply_quant_method`
+        after the routed-expert kernel(s) have been enqueued on the
+        default stream so the join point captures all of the routed-side
+        work as parallel with the shared-side work in the CUDA graph.
+
+        When events are not in use, this is a no-op so callers can
+        invoke it unconditionally.
+        """
+        if not self._use_events:
+            return
+        events = self._events[self._output_idx]
+        if events is None:
+            return
+        _, post_event = events
+        post_event.wait()
 
     @property
     def _output_idx(self) -> int:

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
+import vllm.envs as envs
 from vllm.config import CacheConfig
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
@@ -108,6 +109,28 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             indexer=self.indexer,
         )
 
+        # AMMO OP-010: Two-stream MLA decode pipelining.
+        # When VLLM_OP010_MLA_TWO_STREAM=1, allocate an auxiliary CUDA stream
+        # and a pair of CUDA events on which the q-path and kv-path
+        # preprocessing within `forward()` can be dispatched in parallel.
+        # Mirrors the production-proven pattern used in
+        # vllm/model_executor/layers/deepseek_v4_attention.py (see
+        # `aux_stream` / `ln_events` setup at lines 220-221 there).
+        # When the env var is unset (default), `self.aux_stream` is None and
+        # `maybe_execute_in_parallel` silently degrades to sequential
+        # execution on the current stream — preserving existing behavior
+        # bit-for-bit.
+        self.aux_stream: torch.cuda.Stream | None = None
+        self._mla_events: tuple[torch.cuda.Event, torch.cuda.Event] | None = None
+        if envs.VLLM_OP010_MLA_TWO_STREAM and torch.cuda.is_available():
+            self.aux_stream = torch.cuda.Stream()
+            self._mla_events = (torch.cuda.Event(), torch.cuda.Event())
+            # Make the auxiliary stream available to the underlying
+            # MLAAttention so it can also overlap `do_kv_cache_update`
+            # (concat_and_cache_mla) with the W_UK_T BMM inside
+            # `forward_impl`.
+            self.mla_attn.set_aux_stream(self.aux_stream, self._mla_events)
+
         self.prefix = prefix
 
     def forward(
@@ -116,6 +139,23 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         hidden_states: torch.Tensor,
         llama_4_scaling: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # AMMO OP-010 NOTE: The wrapper-level q-path / kv-path overlap was
+        # initially attempted here via `maybe_execute_in_parallel`, but
+        # `MultiHeadLatentAttentionWrapper.forward()` runs INSIDE the
+        # Inductor-compiled region produced by `@support_torch_compile`
+        # on `DeepseekV2Model`. Dynamo traces `torch.cuda.Event` objects
+        # into integer stream indices, and the resulting Inductor code
+        # passes integers to `record_event`, which fails at runtime with
+        # "expected event to be a torch.Event object". The opaque-op
+        # boundary needed to safely call multi-stream primitives from
+        # inside the compiled graph already exists at the
+        # `MLAAttention` level (`unified_mla_kv_cache_update` /
+        # `unified_mla_attention_with_output`), so all of OP-010's
+        # cross-stream dispatch is concentrated there. The wrapper now
+        # only allocates the aux stream + events and hands them to
+        # `MLAAttention` via `set_aux_stream`. This file therefore
+        # contains no per-forward stream/event ops — keeping it
+        # safe under torch.compile.
         q_c = None
         kv_lora = None
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -33,6 +33,7 @@ from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 
 import vllm._custom_ops as ops
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig, get_current_vllm_config
@@ -362,6 +363,24 @@ class DeepseekV2MoE(nn.Module):
         ):
             self.gate.e_score_correction_bias.data = (
                 self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
+            )
+
+        # AMMO OP-003: pre-cast the bias to bfloat16 on CUDA when the
+        # FlashInfer-TRTLLM MoE backend is used. The TRTLLM kernel
+        # currently requires a bf16 routing bias (see
+        # vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py:332-335),
+        # producing a per-layer .to(bf16) cast on the hot decode path.
+        # Pre-casting at module init eliminates 60 redundant
+        # `bf16_copy_kernel_cuda` launches per decode step. Once the
+        # bias is bf16, the per-layer `.to(torch.bfloat16)` becomes a
+        # no-op (returns the same tensor) and emits no kernel.
+        elif (
+            envs.VLLM_OP003_PREAMBLE_FUSION
+            and self.gate.e_score_correction_bias is not None
+            and self.gate.e_score_correction_bias.data.dtype != torch.bfloat16
+        ):
+            self.gate.e_score_correction_bias.data = (
+                self.gate.e_score_correction_bias.data.to(torch.bfloat16)
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

This PR adds three opt-in, default-off decode-path optimizations for `nvidia/Kimi-K2.6-NVFP4` on NVIDIA B300 (Blackwell, SM 10.3a): TP=4, NVFP4 MoE weights, and the FlashInfer-TRTLLM MoE backend. All three are lossless (CUDA-stream overlap and a redundant-launch elimination — no precision-reducing math), and all three are behind environment flags that default to off.

**The default path is unchanged.** With the three flags unset, every modified path falls through to the original implementation: the scale tensor stays zero-filled, the auxiliary CUDA stream is never allocated, and the MoE overlap keeps its original ordering. Behavior is byte-for-byte identical to base vLLM 0.20.0.

## Optimizations

- **MoE FP4 preamble fusion** (`VLLM_OP003_PREAMBLE_FUSION`, lossless, byte-equal). Two redundant operations on the FlashInfer-TRTLLM (`sf_major`, non-swizzled) FP4 path are removed: `create_fp4_scale_tensor` allocates with `torch.empty` instead of `torch.zeros` (the `cvt_fp16_to_fp4_sf_major` kernel writes every scale-factor address, so the pre-zero fill is dead work), and the per-layer `e_score_correction_bias` bf16 cast is pre-applied at module init so the hot-path cast becomes a no-op. Output is bit-identical (`max_abs_err = 0`, verified including an adversarial `0xFF`-prefill probe).
  - Kernel-level speedup **1.77× warm / 1.60× cold** on the 60-layer fill chain; per-step bf16 copy eliminated (63.95 µs → 0). End-to-end effect is within noise (+0.27% at BS8), so the justification is the byte-equal correctness + kernel speedup, not the E2E delta.
- **Two-stream MLA decode pipelining** (`VLLM_OP010_MLA_TWO_STREAM`, lossless). Dispatches the MLA kv-cache update tail (`concat_and_cache_mla`) on an auxiliary CUDA stream so it overlaps the q-path BMM on the default stream, joined by an event just before the attention kernel reads the cache. All cross-stream dispatch is contained inside the opaque custom ops, so it is safe under `torch.compile`.
  - **+1.29% mean E2E at BS8** (decode-phase time −1.39%); profiling shows 251 overlapping stream pairs with zero ordering violations.
- **Event-based MoE shared/routed two-stream overlap** (`VLLM_OP014_MOE_TWO_STREAM`, lossless). The framework's `Stream.wait_stream`-based shared/routed-expert overlap silently collapses to sequential under CUDA-graph capture. This replaces it with a `torch.cuda.Event` record/wait pattern and enqueues the shared-expert GEMMs before the routed FP4 work to widen the overlap window. When the flag is unset, the original `wait_stream` path runs unchanged.
  - **+3.40% E2E at BS8** (decode-only −3.95%); profiling confirms shared-expert GEMMs land on side streams under the optimized build vs zero in the baseline.

Stacked, all three flags on give a **cumulative +5.93% end-to-end speedup (1.059×) at BS8** versus the unoptimized baseline. Each optimization was measured against a fresh baseline taken after the previous one landed, so the per-optimization deltas above are not directly additive — only the cumulative figure is a like-for-like comparison against the original baseline.

Enable the full stack (the two MoE-backend flags are workload prerequisites, not part of this PR):

```bash
export VLLM_FLASHINFER_MOE_BACKEND=latency   # workload prerequisite
export VLLM_USE_FLASHINFER_MOE_FP4=1         # workload prerequisite
export VLLM_OP003_PREAMBLE_FUSION=1
export VLLM_OP010_MLA_TWO_STREAM=1
export VLLM_OP014_MOE_TWO_STREAM=1
```

> One additional flag, `VLLM_OP013_LAMPORT_AR`, is registered in `envs.py` (default off) but has **no backing implementation** in this PR — it is inert and can be dropped before merge.

## Fixed-batch latency

`vllm bench latency`, B300 (SM 10.3a) · `nvidia/Kimi-K2.6-NVFP4`, NVFP4 MoE weights · TP=4 · `--input-len 10000 --output-len 1000 --num-iters 5 --batch-size 8 --max-model-len 131072 --max-num-seqs 8`, under CUDA graphs + `torch.compile`. Only batch size 8 was benchmarked (the sole configured batch size).

| Optimization | Env flag | E2E effect (BS8) | Notes |
|---|---|---|---|
| MoE FP4 preamble fusion | `VLLM_OP003_PREAMBLE_FUSION` | +0.27% (within noise) | 1.77×/1.60× kernel speedup; value is correctness + kernel-level |
| Two-stream MLA decode pipelining | `VLLM_OP010_MLA_TWO_STREAM` | +1.29% (decode −1.39%) | mean; p50 +0.74% |
| Event-based MoE two-stream overlap | `VLLM_OP014_MOE_TWO_STREAM` | +3.40% (decode −3.95%) | 3.4× the 1% ship threshold |
| **All three (cumulative)** | — | **+5.93% (1.059×)** | vs the original baseline |

## Correctness

GSM8K, greedy decode, 1319 questions, 1.0pp tolerance (a change ships only if `opt ≥ baseline − 1.0pp`). All three optimizations are lossless — they are launch eliminations and stream reorderings that do not change the math — so any per-question churn is benign floating-point order-of-addition jitter (the golden references are non-deterministic).

- **MoE FP4 preamble fusion** — byte-equal kernel output; GSM8K 93.93% vs. 93.93% baseline (0.0pp).
- **Two-stream MLA decode pipelining** — GSM8K 93.93% vs. 93.93% baseline (0.0pp).
- **Event-based MoE two-stream overlap** — GSM8K 93.63% vs. 93.78% baseline (−0.15pp, 29 lost / 27 gained, within tolerance).

## Changes

7 files, +432 / −28. Python-only — an editable install picks them up with no `csrc/` rebuild.

- `_custom_ops.py`, `model_executor/models/deepseek_v2.py` — MoE FP4 preamble fusion (empty-vs-zero scale tensor + init-time bias pre-cast)
- `model_executor/layers/mla.py`, `model_executor/layers/attention/mla_attention.py` — two-stream MLA decode pipelining (aux stream + event plumbing)
- `model_executor/layers/fused_moe/runner/moe_runner.py`, `fused_moe/runner/shared_experts.py` — event-based MoE shared/routed overlap
- `envs.py` — the three flags (all default off; plus the inert `VLLM_OP013_LAMPORT_AR`)

## AI-assisted contribution

These optimizations were generated by an automated, gated kernel-optimization process driving Claude (Anthropic), with human review. Every shipped change passed bit-level / GSM8K correctness, kernel-speedup, dispatch, and end-to-end latency checks; all numbers were measured on real B300 (SM 10.3a / Blackwell) hardware under CUDA graphs + `torch.compile`. With the flags unset the default path is unchanged from base vLLM 0.20.0.
