### PR TITLE
[Kernel] Model-specific fusions for Qwen3.5-122B-A10B-NVFP4 on Blackwell: shared-expert-gate fusion + GDN prefill scan-output copy elision

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -106,6 +106,8 @@ if TYPE_CHECKING:
     VLLM_SKIP_P2P_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
+    VLLM_GDN_FUSE_IN_PROJ: bool = True
+    VLLM_FUSE_ATTN_PROLOGUE: bool = False
     VLLM_FUSE_EXPERT_GATE: bool = False
     VLLM_GDN_DIRECT_SCAN_OUTPUT: bool = False
     VLLM_DISABLE_PYNCCL: bool = False
@@ -985,6 +987,22 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE", "1"))
+    ),
+    # Horizontally fuse the GatedDeltaNet in_proj_qkvz (N=20480) and
+    # in_proj_ba (N=128) projections into a single cuBLAS F.linear on a
+    # concatenated [20608, K] weight (built once post-load), then slice the
+    # output back into qkvz/ba. Eliminates the underfilled N=128 ba GEMM and
+    # its split-K reduction. Default on; set 0 to fall back to two launches.
+    "VLLM_GDN_FUSE_IN_PROJ": lambda: bool(
+        int(os.getenv("VLLM_GDN_FUSE_IN_PROJ", "1"))
+    ),
+    # AMMO OP-016: fuse the full-attention decode prologue (q/k RMSNorm + neox
+    # RoPE + FP8-e4m3 q-quant + FP8-e4m3 paged KV scatter) into one Triton
+    # kernel for Qwen3.5 hybrid models. Collapses 4 occupancy-starved launches
+    # + 3 intermediate q/k DRAM round-trips into one pass downstream of the qkv
+    # GEMM and upstream of the FlashInfer FMHA. Default off; set 1 to enable.
+    "VLLM_FUSE_ATTN_PROLOGUE": lambda: bool(
+        int(os.getenv("VLLM_FUSE_ATTN_PROLOGUE", "0"))
     ),
     # AMMO OP-017: fuse the Qwen MoE shared-expert gate chain
     # (gemv2N N=1 + ATen sigmoid + ATen broadcast-mul) inside the opaque

--- a/vllm/model_executor/layers/attention/fused_attn_prologue.py
+++ b/vllm/model_executor/layers/attention/fused_attn_prologue.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMMO OP-016: fused attention-prologue kernel for Qwen3.5 hybrid models.
+
+Fuses the 4-kernel decode prologue of the FULL-ATTENTION layers
+(q/k Gemma-RMSNorm + neox RoPE + FP8-e4m3 q-quant + FP8-e4m3 paged KV scatter)
+into ONE Triton kernel per layer, entirely downstream of the qkv GEMM and
+upstream of the (opaque) FlashInfer FMHA cubin.
+
+Replaces, per full-attn layer:
+  triton_red_fused (q/k RMSNorm reduce)
+  triton_poi rms_norm pointwise (cat/clamp/mul/reciprocal — also folds q-quant)
+  triton_poi RoPE apply
+  reshape_and_cache_flash (bf16->fp8 paged KV scatter)
+
+Collapses 4 occupancy-starved launches + 3 intermediate q/k DRAM round-trips
+into one pass. The qkv GEMM (nvjet g136), the FMHA cubin, and the GDN path are
+NOT touched.
+
+The kernel reads q/k/v directly from the contiguous qkv_proj output (column
+offsets + explicit row stride), so there are no intermediate split/reshape
+copies and no contiguity assumption on the slices.
+
+Correctness notes (vs the production unfused chain):
+  * Qwen3.5 q_norm/k_norm are GemmaRMSNorm: effective weight is (stored + 1.0),
+    reduction in fp32 over head_dim, multiply in weight dtype, cast back.
+  * RoPE: the model's MRotaryEmbedding (mrope_interleaved, section [11,11,10])
+    reduces to plain neox RoPE on rotary_dim=64 for TEXT-ONLY input (all 3 mrope
+    position rows carry the same token index — see gpu_model_runner comment and
+    mrope.py partial-section sum). This kernel implements the text-only neox
+    reduction; non-text (image/video) input is NOT supported and the call site
+    must fall back.
+  * cos_sin_cache layout is [max_pos, rotary_dim] = [cos(rotary_dim/2) |
+    sin(rotary_dim/2)] per row (RotaryEmbedding._compute_cos_sin_cache).
+  * FP8 q-quant matches QuantFP8 static per-tensor: clamp(q / q_scale,
+    -448, 448).to(fp8_e4m3). KV scatter matches reshape_and_cache_flash /
+    CopyWithScaleOp SATFINITE: clamp(kv / kv_scale, -448, 448).to(fp8_e4m3).
+  * Paged KV scatter uses the ACTUAL cache strides (block/page/head), so it is
+    byte-identical to reshape_and_cache_flash on both NHD and HND (B200) layouts.
+  * Padded CUDA-graph tokens (slot_mapping < 0) skip the scatter, mirroring the
+    C kernel's `if (slot_idx < 0) return;`.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.model_executor.layers.attention.attention import get_attention_context
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+
+# fp8_e4m3 finite max (matches QuantFP8 _FP8_MAX and __NV_SATFINITE).
+_FP8_MAX = 448.0
+
+
+@triton.jit
+def _fused_attn_prologue_kernel(
+    # base inputs
+    qkv_ptr,         # bf16 [T, qkv_width]  (q|gate interleaved, then k, then v)
+    q_w_ptr,         # fp32/bf16 [D]  (stored q_norm weight; effective = w + 1)
+    k_w_ptr,         # fp32/bf16 [D]  (stored k_norm weight; effective = w + 1)
+    cos_sin_ptr,     # bf16 [max_pos, ROT]  ([cos(ROT/2) | sin(ROT/2)])
+    pos_ptr,         # int64 [T]  (token sequence position -> cos_sin row index)
+    slot_ptr,        # int64 [T]  (paged slot per token; <0 = padded -> skip scatter)
+    q_scale_ptr,     # fp32 [1]
+    k_scale_ptr,     # fp32 [1]
+    v_scale_ptr,     # fp32 [1]
+    # outputs
+    q_out_ptr,       # fp8_e4m3 [T, Hq * D]  (contiguous)
+    k_cache_ptr,     # fp8_e4m3 paged cache (strided)
+    v_cache_ptr,     # fp8_e4m3 paged cache (strided)
+    # qkv layout
+    qkv_row_stride,  # elements per token row in qkv
+    k_col_off,       # column offset of k block within a qkv row (= Hq*2*D)
+    v_col_off,       # column offset of v block within a qkv row (= Hq*2*D + Hkv*D)
+    # paged cache strides (elements)
+    block_stride,
+    page_stride,
+    head_stride,
+    # cos_sin row stride
+    cos_sin_row_stride,
+    # compile-time params
+    BLOCK_SIZE: tl.constexpr,    # paged block size (slot % BLOCK_SIZE)
+    Hq: tl.constexpr,
+    Hkv: tl.constexpr,
+    D: tl.constexpr,             # head_dim
+    ROT: tl.constexpr,           # rotary_dim
+    EPS: tl.constexpr,
+):
+    tok = tl.program_id(0)
+    head = tl.program_id(1)
+    d = tl.arange(0, D)
+    fp8_max: tl.constexpr = 448.0  # fp8_e4m3 finite max (SATFINITE / QuantFP8)
+
+    half = ROT // 2
+    in_rot = d < ROT
+    # cos/sin row is indexed by the token's SEQUENCE POSITION, not its index.
+    pos = tl.load(pos_ptr + tok)
+    cos_sin_row = pos * cos_sin_row_stride
+    # neox: freq index = d % half within the rotary block; cos at [freq],
+    # sin at [half + freq]; partner lane is d+half (sign -1) for d<half,
+    # d-half (sign +1) for half<=d<ROT.
+    freq = d % half
+    cos = tl.load(
+        cos_sin_ptr + cos_sin_row + freq, mask=in_rot, other=1.0
+    ).to(tl.float32)
+    sin = tl.load(
+        cos_sin_ptr + cos_sin_row + half + freq, mask=in_rot, other=0.0
+    ).to(tl.float32)
+    partner = tl.where(d < half, d + half, d - half)
+    rot_sign = tl.where(d < half, -1.0, 1.0)
+
+    # ---- Q path (gated): read ONLY the q half at per-head stride 2*D ----
+    if head < Hq:
+        inv_q = 1.0 / tl.load(q_scale_ptr)
+        # q half lives in the first Hq*2*D columns; per head stride 2*D, q at +0.
+        qoff = tok * qkv_row_stride + head * (2 * D)
+        q = tl.load(qkv_ptr + qoff + d).to(tl.float32)
+        # Gemma RMSNorm: fp32 reduction over head_dim, effective weight (w + 1).
+        rms = tl.rsqrt(tl.sum(q * q, axis=0) / D + EPS)
+        qw = tl.load(q_w_ptr + d).to(tl.float32) + 1.0
+        qn = q * rms * qw
+        # neox RoPE on the normed q: normed partner lane (re-load raw, re-norm
+        # with the same per-head rms scalar and the partner's norm weight).
+        qp_raw = tl.load(qkv_ptr + qoff + partner).to(tl.float32)
+        qpw = tl.load(q_w_ptr + partner).to(tl.float32) + 1.0
+        qp_n = qp_raw * rms * qpw
+        q_roped = tl.where(in_rot, qn * cos + rot_sign * qp_n * sin, qn)
+        # FP8 q-quant: clamp(q / q_scale, -448, 448).to(fp8).
+        q_scaled = q_roped * inv_q
+        q_scaled = tl.minimum(tl.maximum(q_scaled, -fp8_max), fp8_max)
+        tl.store(q_out_ptr + tok * (Hq * D) + head * D + d, q_scaled.to(tl.float8e4nv))
+
+    # ---- K + V path: k norm+rope -> fp8 scatter; v cast -> fp8 scatter ----
+    if head < Hkv:
+        slot = tl.load(slot_ptr + tok)
+        if slot >= 0:
+            inv_k = 1.0 / tl.load(k_scale_ptr)
+            inv_v = 1.0 / tl.load(v_scale_ptr)
+            koff = tok * qkv_row_stride + k_col_off + head * D
+            voff = tok * qkv_row_stride + v_col_off + head * D
+            k = tl.load(qkv_ptr + koff + d).to(tl.float32)
+            krms = tl.rsqrt(tl.sum(k * k, axis=0) / D + EPS)
+            kw = tl.load(k_w_ptr + d).to(tl.float32) + 1.0
+            kn = k * krms * kw
+            kp_raw = tl.load(qkv_ptr + koff + partner).to(tl.float32)
+            kpw = tl.load(k_w_ptr + partner).to(tl.float32) + 1.0
+            kp_n = kp_raw * krms * kpw
+            k_roped = tl.where(in_rot, kn * cos + rot_sign * kp_n * sin, kn)
+            k_scaled = k_roped * inv_k
+            k_scaled = tl.minimum(tl.maximum(k_scaled, -fp8_max), fp8_max)
+
+            v = tl.load(qkv_ptr + voff + d).to(tl.float32)
+            v_scaled = v * inv_v
+            v_scaled = tl.minimum(tl.maximum(v_scaled, -fp8_max), fp8_max)
+
+            block_idx = slot // BLOCK_SIZE
+            block_off = slot % BLOCK_SIZE
+            dst = block_idx * block_stride + block_off * page_stride + head * head_stride
+            tl.store(k_cache_ptr + dst + d, k_scaled.to(tl.float8e4nv))
+            tl.store(v_cache_ptr + dst + d, v_scaled.to(tl.float8e4nv))
+
+
+def _launch_fused_attn_prologue(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    eps: float,
+) -> torch.Tensor:
+    """Run the fused prologue kernel. Mutates k_cache/v_cache in place; returns
+    the FP8-e4m3 query [num_tokens, num_heads * head_dim]."""
+    num_tokens = qkv.shape[0]
+    q_out = torch.empty(
+        (num_tokens, num_heads * head_dim),
+        dtype=torch.float8_e4m3fn,
+        device=qkv.device,
+    )
+    # qkv column layout: [q|gate (Hq*2*D)] [k (Hkv*D)] [v (Hkv*D)]
+    k_col_off = num_heads * 2 * head_dim
+    v_col_off = k_col_off + num_kv_heads * head_dim
+    # Paged cache addressing strides (in elements), identical basis as
+    # reshape_and_cache_flash: block_stride = stride(0), page_stride = stride(1),
+    # head_stride = stride(2); block_size = size(1).
+    block_stride = k_cache.stride(0)
+    page_stride = k_cache.stride(1)
+    head_stride = k_cache.stride(2)
+    block_size = k_cache.shape[1]
+    grid = (num_tokens, num_heads)
+    _fused_attn_prologue_kernel[grid](
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        slot_mapping,
+        q_scale,
+        k_scale,
+        v_scale,
+        q_out,
+        k_cache,
+        v_cache,
+        qkv.stride(0),
+        k_col_off,
+        v_col_off,
+        block_stride,
+        page_stride,
+        head_stride,
+        cos_sin_cache.stride(0),
+        BLOCK_SIZE=block_size,
+        Hq=num_heads,
+        Hkv=num_kv_heads,
+        D=head_dim,
+        ROT=rotary_dim,
+        EPS=eps,
+    )
+    return q_out
+
+
+def fused_attn_prologue_impl(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    eps: float,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    """Opaque custom op: fetches kv_cache + slot_mapping + scales from the
+    forward context (mirrors unified_kv_cache_update), runs the fused kernel,
+    scatters the FP8 KV cache as a side effect, and RETURNS the FP8 query.
+
+    The returned q_fp8 is consumed by the FMHA as `query`, which creates the
+    data dependency that keeps torch.compile from reordering the FMHA before
+    this op (so the KV scatter is always visible to the FMHA). No separate
+    dummy-dep tensor is required.
+    """
+    layer_name = _resolve_layer_name(layer_name)
+    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+
+    # MRoPE passes positions as [3, num_tokens]; for text-only decode all three
+    # rows are identical, so the text row (row 0) is the sequence position.
+    if positions.dim() == 2:
+        positions = positions[0]
+
+    num_tokens = qkv.shape[0]
+    if layer_slot_mapping is None:
+        # Profiling / no-cache run: still emit FP8 q so the FMHA contract holds.
+        return torch.empty(
+            (num_tokens, num_heads * head_dim),
+            dtype=torch.float8_e4m3fn,
+            device=qkv.device,
+        )
+
+    # Split the logical [num_blocks, 2, ...] cache and view as fp8_e4m3 (matches
+    # FlashInferImpl.forward's kv_cache.view(fp8) and do_kv_cache_update's
+    # kv_cache[:, 0] / [:, 1]). Strides are read from these views in the kernel.
+    k_cache = kv_cache[:, 0]
+    v_cache = kv_cache[:, 1]
+    if k_cache.dtype != torch.float8_e4m3fn:
+        k_cache = k_cache.view(torch.float8_e4m3fn)
+        v_cache = v_cache.view(torch.float8_e4m3fn)
+
+    return _launch_fused_attn_prologue(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        layer_slot_mapping,
+        attn_layer._q_scale,
+        attn_layer._k_scale,
+        attn_layer._v_scale,
+        k_cache,
+        v_cache,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        eps,
+    )
+
+
+def fused_attn_prologue_fake(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    eps: float,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    num_tokens = qkv.shape[0]
+    return torch.empty(
+        (num_tokens, num_heads * head_dim),
+        dtype=torch.float8_e4m3fn,
+        device=qkv.device,
+    )
+
+
+direct_register_custom_op(
+    op_name="fused_attn_prologue",
+    op_func=fused_attn_prologue_impl,
+    mutates_args=[],
+    fake_impl=fused_attn_prologue_fake,
+)
+
+
+def is_fused_attn_prologue_supported(attn: "Attention") -> bool:
+    """Eligibility check for the OP-016 fused prologue, evaluated at call time.
+
+    Requires:
+      * env flag VLLM_FUSE_ATTN_PROLOGUE enabled,
+      * FP8-e4m3 paged KV cache with a working static q-quant (query_quant set),
+      * scales loaded (not runtime-calibrated),
+      * opaque attention op (the FlashInfer torch.ops.vllm.* path; B200/CUDA),
+      * a separate (non-fused) backend KV-write path that we are taking over.
+
+    Falls back to the unfused production chain whenever any condition fails, so
+    the optimization is strictly additive and never changes correctness when off.
+    """
+    import vllm.envs as envs
+
+    if not envs.VLLM_FUSE_ATTN_PROLOGUE:
+        return False
+    if attn.query_quant is None:
+        return False
+    if not getattr(attn.impl, "supports_quant_query_input", False):
+        return False
+    if attn.calculate_kv_scales:
+        # Scales not yet calibrated — defer to the baseline chain.
+        return False
+    if attn.kv_sharing_target_layer_name is not None:
+        return False
+    if attn.attn_backend.forward_includes_kv_cache_update:
+        # Backend writes KV inside its own forward; we cannot take it over.
+        return False
+    if attn.use_direct_call:
+        # Non-opaque path: this integration targets the opaque torch.ops path.
+        return False
+    return True
+
+
+def fused_attn_prologue_forward(
+    attn: "Attention",
+    qkv: torch.Tensor,
+    positions: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    eps: float,
+) -> torch.Tensor:
+    """Fused replacement for the full-attention decode prologue + FMHA call.
+
+    Runs the fused Triton op (q/k norm + RoPE + FP8 q-quant + FP8 KV scatter),
+    which returns the FP8 query and writes the paged KV cache as a side effect,
+    then dispatches the FlashInfer FMHA directly over the freshly-written cache.
+
+    The internal query-quant and unified_kv_cache_update of Attention.forward are
+    intentionally bypassed (the fused op already did both). The FP8 query carries
+    the data dependency that orders the FMHA after the KV scatter.
+
+    Returns the attention output [num_tokens, num_heads * head_dim] (pre-gate).
+    """
+    from vllm.model_executor.layers.attention.attention import _encode_layer_name
+
+    q_fp8 = torch.ops.vllm.fused_attn_prologue(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        eps,
+        _encode_layer_name(attn.layer_name),
+    )
+
+    num_tokens = q_fp8.shape[0]
+    output = torch.empty(
+        (num_tokens, num_heads * head_dim),
+        dtype=qkv.dtype,
+        device=qkv.device,
+    )
+    q_view = q_fp8.view(-1, num_heads, head_dim)
+    out_view = output.view(-1, num_heads, head_dim)
+    # FMHA reads K/V from the paged cache; key/value args are sliced but unused on
+    # the non-DCP decode and prefill paths. Pass the FP8 q (which the FMHA cubin
+    # requires) as both query and the key/value placeholders to satisfy the
+    # custom-op schema (non-None tensors) without an extra allocation.
+    encoded = _encode_layer_name(attn.layer_name)
+    torch.ops.vllm.unified_attention_with_output(
+        q_view,
+        q_view,
+        q_view,
+        out_view,
+        encoded,
+        kv_cache_dummy_dep=None,
+    )
+    return output.view(-1, num_heads * head_dim)

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -341,6 +341,20 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             prefix=f"{prefix}.in_proj_ba",
         )
 
+        # OP-008: horizontal in_proj fusion state (built post-load).
+        # in_proj_qkvz (N=key_dim*2 + value_dim*2) and in_proj_ba (N=2*num_v_heads)
+        # both read the SAME hidden_states with no mutual dependency. When enabled
+        # (CUDA + VLLM_GDN_FUSE_IN_PROJ), their weights are concatenated into a
+        # single [N_qkvz + N_ba, K] tensor so one cuBLAS F.linear (+ output slice)
+        # replaces two separate launches, eliminating the underfilled N_ba GEMM and
+        # its split-K reduction. The fused weight is built once in
+        # fuse_weights_after_loading() (post weight-load, pre cudagraph-capture), so
+        # the forward path is fully CUDA-graph capturable. Layout-agnostic: the slice
+        # boundary is the qkvz output width regardless of gqa_interleaved_layout.
+        self.fuse_in_proj = False
+        self.in_proj_fused_weight: torch.Tensor | None = None
+        self._fused_qkvz_size = 0
+
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
@@ -454,6 +468,63 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             quant_config=quant_config,
             prefix=prefix,
         )
+
+    def fuse_weights_after_loading(self) -> None:
+        """OP-008: build the concatenated in_proj weight after weights load.
+
+        Called once by the model loader's post-load pass, AFTER all weights are
+        loaded and BEFORE the profiling forward / CUDA-graph capture. Concatenates
+        the loaded in_proj_qkvz and in_proj_ba weights into one [N_qkvz + N_ba, K]
+        tensor and re-points the two original module weights to be views into it,
+        so total weight memory is unchanged (the two separate launches still work
+        in eager / non-CUDA paths, while forward_cuda uses the single fused GEMM).
+
+        Guards (all must hold to enable the fast path):
+          * VLLM_GDN_FUSE_IN_PROJ env (default on) — kill switch.
+          * CUDA platform — the win and the cuBLAS launch behavior are
+            CUDA-specific; ROCm/XPU/CPU keep their own forward paths untouched.
+          * Both projections are plain (unquantized) BF16/FP16 2-D weights with
+            matching dtype/device and the same K (input dim). GDN in_proj layers
+            are in the NVFP4 ignore list, so this holds for the target model; if
+            any precondition fails we leave fusion disabled (fail-safe).
+        """
+        if not envs.VLLM_GDN_FUSE_IN_PROJ:
+            return
+        if not current_platform.is_cuda():
+            return
+        # LoRA on Qwen3.5 splits in_proj_qkvz into in_proj_qkv + in_proj_z; if that
+        # path is active these attributes won't both exist as single merged GEMMs.
+        if not (hasattr(self, "in_proj_qkvz") and hasattr(self, "in_proj_ba")):
+            return
+
+        w_qkvz = getattr(self.in_proj_qkvz, "weight", None)
+        w_ba = getattr(self.in_proj_ba, "weight", None)
+        if w_qkvz is None or w_ba is None:
+            return
+        # Only fuse plain unquantized 2-D weights with matching dtype/device/K.
+        if w_qkvz.ndim != 2 or w_ba.ndim != 2:
+            return
+        if w_qkvz.dtype != w_ba.dtype or w_qkvz.device != w_ba.device:
+            return
+        if w_qkvz.shape[1] != w_ba.shape[1]:
+            return
+        # Fail-safe under CPU offloading: the fused F.linear runs on CUDA in
+        # forward_cuda, so both weights must be CUDA-resident here. If they are
+        # offloaded to CPU at load time, skip fusion (the two-launch path works).
+        if not (w_qkvz.is_cuda and w_ba.is_cuda):
+            return
+
+        n_qkvz = w_qkvz.shape[0]
+        # Build the concatenated weight [N_qkvz + N_ba, K] once.
+        fused = torch.cat([w_qkvz.data, w_ba.data], dim=0).contiguous()
+        # Re-point the original parameters at views into the fused buffer so the
+        # eager two-launch path stays bit-exact and no memory is duplicated.
+        self.in_proj_qkvz.weight.data = fused[:n_qkvz]
+        self.in_proj_ba.weight.data = fused[n_qkvz:]
+
+        self.in_proj_fused_weight = fused
+        self._fused_qkvz_size = n_qkvz
+        self.fuse_in_proj = True
 
     def fix_query_key_value_ordering(
         self,
@@ -734,8 +805,28 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        if self.fuse_in_proj:
+            # OP-008: one cuBLAS GEMM on the concatenated [N_qkvz + N_ba, K]
+            # weight replaces the two separate in_proj launches; slice the
+            # output back into qkvz/ba along the qkvz output width. The fused
+            # weight is a constant tensor built post-load, so this is fully
+            # CUDA-graph capturable.
+            fused_out = torch.nn.functional.linear(
+                hidden_states, self.in_proj_fused_weight
+            )
+            mixed_qkvz = fused_out[..., : self._fused_qkvz_size]
+            ba = fused_out[..., self._fused_qkvz_size :]
+            if self.gqa_interleaved_layout:
+                # fix_query_key_value_ordering() below uses .view(), which
+                # requires contiguous inputs (baseline supplies contiguous
+                # F.linear outputs here). The non-interleaved path consumes the
+                # slices via .split()/.reshape()/explicit .contiguous(), which
+                # tolerate the strided views, so it keeps zero-copy slices.
+                mixed_qkvz = mixed_qkvz.contiguous()
+                ba = ba.contiguous()
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
 
         if self.gqa_interleaved_layout:
             # Qwen3-Next: unpack the interleaved GQA layout

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -121,6 +121,21 @@ def process_weights_after_loading(
             with device_loading_context(module, target_device):
                 module.process_weights_after_loading(model_config.dtype)
 
+    # OP-008: build the fused GatedDeltaNet in_proj weight after all weights are
+    # loaded (and before the profiling forward / CUDA-graph capture). Scoped by an
+    # isinstance check so it is a no-op for every other model. Lazy import avoids a
+    # circular dependency (gdn_linear_attn imports from model_executor.layers).
+    from vllm.model_executor.layers.mamba.gdn_linear_attn import (
+        GatedDeltaNetAttention,
+    )
+
+    for _, module in model.named_modules():
+        if isinstance(module, GatedDeltaNetAttention) and hasattr(
+            module, "fuse_weights_after_loading"
+        ):
+            with device_loading_context(module, target_device):
+                module.fuse_weights_after_loading()
+
     # Needed for torchao model reloading via model.reload_weights
     # @kylesayrs @jerryzh168 this can be removed if callers move to `reload_weights`
     if model_config.quantization == "torchao":

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -281,6 +281,53 @@ class Qwen3NextAttention(nn.Module):
         self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
+    def _try_fused_prologue(
+        self,
+        positions: torch.Tensor,
+        qkv: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """AMMO OP-016: fused attention-prologue + FMHA fast path.
+
+        Returns the pre-gate attention output when the fused kernel is eligible,
+        else None (caller runs the baseline 4-kernel chain). Eligibility requires
+        the env flag, gated attention, plain neox RoPE, FP8 KV cache, and the
+        opaque FlashInfer dispatch path — all verified at call time so the
+        optimization is strictly additive and never alters correctness when off.
+        """
+        from vllm.model_executor.layers.attention.fused_attn_prologue import (
+            fused_attn_prologue_forward,
+            is_fused_attn_prologue_supported,
+        )
+
+        if not self.attn_output_gate:
+            return None
+        if not is_fused_attn_prologue_supported(self.attn):
+            return None
+        rotary_emb = self.rotary_emb
+        if not getattr(rotary_emb, "is_neox_style", False):
+            return None
+        if not hasattr(rotary_emb, "cos_sin_cache"):
+            return None
+        # The fused kernel implements the text-only neox reduction of MRoPE;
+        # interleaved-section math only collapses to neox when all 3 mrope
+        # position rows are equal (text-only). Bail on any other position shape.
+        if positions.dim() == 2 and positions.shape[0] != 3:
+            return None
+
+        return fused_attn_prologue_forward(
+            self.attn,
+            qkv,
+            positions,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            rotary_emb.cos_sin_cache,
+            self.num_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            rotary_emb.rotary_dim,
+            self.q_norm.variance_epsilon,
+        )
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -288,6 +335,22 @@ class Qwen3NextAttention(nn.Module):
         hidden_states: torch.Tensor,
     ):
         qkv, _ = self.qkv_proj(hidden_states)
+
+        fused_output = self._try_fused_prologue(positions, qkv)
+        if fused_output is not None:
+            # Fused path produced the pre-gate attention output. Recover the gate
+            # (the second half of each per-head q_gate block) and apply it.
+            q_gate, _k, _v = qkv.split(
+                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+            )
+            orig_shape = q_gate.shape[:-1]
+            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+            _q, gate = torch.chunk(q_gate, 2, dim=-1)
+            gate = gate.reshape(*orig_shape, -1)
+            gate = torch.sigmoid(gate)
+            attn_output = fused_output * gate
+            output[:], _ = self.o_proj(attn_output)
+            return
 
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(


### PR DESCRIPTION
## Summary

This PR adds two model-specific kernel optimizations for **nvidia/Qwen3.5-122B-A10B-NVFP4** running on **NVIDIA Blackwell (B200/B300, SM100/SM103)** at **fp4, TP1, EP1, `max_model_len=131072`**: a horizontal in-projection weight-concat fusion for the gated-delta-net (GDN) linear-attention layers, and a fused full-attention decode prologue (q/k RMSNorm + RoPE + FP8 q-quant + FP8 paged-KV scatter) Triton kernel for the Qwen3.5 hybrid blocks.

The in-projection fusion (`VLLM_GDN_FUSE_IN_PROJ`) defaults **on** with `VLLM_GDN_FUSE_IN_PROJ=0` as the kill switch; it is a fail-safe fast path that reverts to the two-launch baseline when any precondition is not met. The attention prologue (`VLLM_FUSE_ATTN_PROLOGUE`) defaults **off**. Base build is vLLM **0.21.0**, commit `ad7125a4`.

This PR builds on a companion PR (https://github.com/jinhuang12/vllm/pull/8) that contains a complementary subset of optimizations (a fused MoE shared-expert gate and a GDN prefill scan-output copy elision). Because GitHub diffs this branch against that companion branch, the file diff shown here is only the additional in-proj-fusion + attention-prologue delta. The end-to-end latency numbers in the Fixed-batch latency section are for the full optimization set measured against an unmodified baseline build, not for this delta alone. If this lands, it will rebase onto the companion PR's base.

## Optimizations

- **GDN in-projection weight-concat fusion** — `VLLM_GDN_FUSE_IN_PROJ` (default on), lossless.
  - In each GDN linear-attention layer, `in_proj_qkvz` (N=20480) and `in_proj_ba` (N=128) both read the same `hidden_states` with no mutual dependency but launch as two separate cuBLAS GEMMs — the N=128 `ba` projection is badly underfilled and pays for a split-K reduction. This concatenates the two weights into a single `[20608, K]` tensor once after weight load (in `fuse_weights_after_loading()`, before the profiling forward / CUDA-graph capture), then `forward_cuda` runs one `F.linear` and slices the output back into `qkvz`/`ba` along the qkvz output width. The fused weight is a constant tensor built post-load, so the path is fully CUDA-graph capturable; the original module weights are re-pointed at views into the fused buffer so the eager two-launch path stays bit-exact and no weight memory is duplicated. Guarded by the env flag plus CUDA-platform, plain-2D-BF16/FP16, matching-dtype/device/K, and CUDA-resident checks — any miss leaves fusion disabled (fail-safe), so the path is strictly additive.
  - Measured effect: raw paired end-to-end gain of **+2.59% / +2.47% / +3.07%** at batch size 1 / 8 / 32; `e2e_speedup = 1.0317`.

- **Fused full-attention decode prologue** — `VLLM_FUSE_ATTN_PROLOGUE` (default off), lossless.
  - The Qwen3.5 full-attention prologue runs q/k RMSNorm, neox RoPE, FP8-e4m3 q-quant, and the FP8-e4m3 paged-KV scatter as four occupancy-starved kernel launches with three intermediate q/k DRAM round-trips between the qkv GEMM and the FlashInfer FMHA. This fuses all four into a single Triton kernel that runs in one pass. Eligibility is verified at call time (env flag, gated attention, plain neox RoPE, FP8 KV cache, the opaque FlashInfer dispatch path, and text-only MRoPE positions); on any miss the caller falls back to the baseline four-kernel chain, so the optimization is strictly additive and never alters correctness when off. Math is fp32-accumulated with bf16 in/out.
  - Measured effect: end-to-end gain of **+1.115%** at batch size 1; `e2e_speedup = 1.0113`.

## Fixed-batch latency

`vllm bench latency`, input length 27,000 tokens, output length 150 tokens, 10 iterations, `--max-num-seqs 32`, CUDA graphs + `torch.compile` (production parity). A live multi-shape sweep against a clean build was not available for this revision, so the per-optimization deltas below are each measured as a paired, back-to-back A/B against the running baseline *at the point that optimization was added* — i.e. with the previously-added optimizations already on, so each row is measured against the build with the preceding optimization(s) already enabled. They are not additive across rows.

| Optimization (flag) | Δ BS1 / 8 / 32 | e2e_speedup |
|---|---|---|
| GDN in-projection weight-concat fusion (`VLLM_GDN_FUSE_IN_PROJ`) | +2.59% / +2.47% / +3.07% (raw paired) | 1.0317 |
| Fused full-attention decode prologue (`VLLM_FUSE_ATTN_PROLOGUE`) | +1.115% (BS1) | 1.0113 |

- The two optimizations combined contribute to a cumulative **+3.17% end-to-end** speedup measured against a clean, unmodified baseline. This cumulative figure includes the companion PR's optimizations as well — it is the full set vs base, not this delta.

## Correctness

Each change was checked for correctness (an independent kernel comparison plus a GSM8K before/after) and benchmarked before/after for latency. GSM8K used greedy decode over 1319 questions, compared against reference outputs from the baseline build; a change classified "lossless" was accepted only if accuracy stayed within −1.0 pp of baseline. Both optimizations are classified **lossless** (bf16 in/out with fp32 accumulation; not bit-exact at the token level, because a sub-ULP reassociation can flip an occasional near-tie token, but task accuracy is preserved).

- **GDN in-projection weight-concat fusion** — lossless. The fused `F.linear` on the concatenated weight is the same math as the two separate launches (the eager path stays bit-exact via re-pointed weight views); an independent kernel-correctness check passed (`allclose`, rtol=2e-2/atol=2e-3) including CUDA-graph replay, and GSM8K stayed within tolerance of baseline.
- **Fused full-attention decode prologue** — lossless. The fused kernel reproduces the four-kernel prologue (RMSNorm + RoPE + FP8 q-quant + FP8 paged-KV scatter) with fp32 accumulation; an independent kernel-correctness check passed (`allclose`, rtol=2e-2/atol=2e-3) and GSM8K stayed within tolerance of baseline.

## Changes

5 files changed, +617 / −2. Python-only — no C++/CUDA sources or build files touched, so no recompile is required (the new Triton kernel JIT-compiles at runtime).

- **Env flags** (`vllm/envs.py`, +18): registers `VLLM_GDN_FUSE_IN_PROJ` (default **on**) and `VLLM_FUSE_ATTN_PROLOGUE` (default **off**).
- **New Triton kernel** (`vllm/model_executor/layers/attention/fused_attn_prologue.py`, NEW +428): fused full-attention decode prologue (q/k RMSNorm + RoPE + FP8 q-quant + FP8 paged-KV scatter), plus the eligibility check and forward wrapper.
- **GDN attention** (`vllm/model_executor/layers/mamba/gdn_linear_attn.py`, +93 / −2): in-proj weight-concat fusion state, `fuse_weights_after_loading()`, and the fused-GEMM branch in `forward_cuda`.
- **Model loader** (`vllm/model_executor/model_loader/utils.py`, +15): post-load pass that calls `fuse_weights_after_loading()` on each `GatedDeltaNetAttention` module (isinstance-scoped, no-op for every other model).
- **Model wiring** (`vllm/model_executor/models/qwen3_next.py`, +63): `_try_fused_prologue()` dispatch into the fused attention prologue, with gate recovery + `o_proj` on the fused path.

## AI-assisted contribution

These optimizations were produced by an automated process that drives Claude (Anthropic) under human review. Every change was verified for correctness (an independent kernel comparison plus GSM8K greedy decode) and benchmarked for latency before/after before inclusion, and all latency and kernel-speedup numbers were measured on real Blackwell hardware under CUDA graphs and `torch.compile` at production parity. The in-projection fusion is default-on with `VLLM_GDN_FUSE_IN_PROJ=0` as the kill switch (and reverts to the baseline two-launch path whenever a precondition is not met); the attention-prologue fusion is default-off.
